### PR TITLE
feat: add correlation id between lua fields and configurator

### DIFF
--- a/src/SCRIPTS/RF2/PAGES/filters.lua
+++ b/src/SCRIPTS/RF2/PAGES/filters.lua
@@ -14,29 +14,29 @@ local fields = {}
 local gyroFilterType = { [0] = "NONE", "1ST", "2ND" }
 
 labels[#labels + 1] = { t = "Gyro lowpass 1",           x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Filter type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = #gyroFilterType, vals = { 2 }, table = gyroFilterType,  id="gyroLowpassType" }
-fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 3, 4 },      id="gyroLowpassFrequency" }
+fields[#fields + 1] = { t = "Filter type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = #gyroFilterType, vals = { 2 }, table = gyroFilterType,  id = "gyroLowpassType" }
+fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 3, 4 },      id = "gyroLowpassFrequency" }
 
 labels[#labels + 1] = { t = "Gyro lowpass 1 dynamic",   x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Min cutoff",               x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000, vals = { 16, 17 },    id="gyroLowpassDynMinFrequency" }
-fields[#fields + 1] = { t = "Max cutoff",               x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000, vals = { 18, 19 },    id="gyroLowpassDynMaxFrequency" }
+fields[#fields + 1] = { t = "Min cutoff",               x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000, vals = { 16, 17 },    id = "gyroLowpassDynMinFrequency" }
+fields[#fields + 1] = { t = "Max cutoff",               x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000, vals = { 18, 19 },    id = "gyroLowpassDynMaxFrequency" }
 
 labels[#labels + 1] = { t = "Gyro lowpass 2",           x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Filter type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = #gyroFilterType, vals = { 5 }, table = gyroFilterType,  id="gyroLowpass2Type" }
-fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 6, 7 },      id="gyroLowpass2Frequency" }
+fields[#fields + 1] = { t = "Filter type",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = #gyroFilterType, vals = { 5 }, table = gyroFilterType,  id = "gyroLowpass2Type" }
+fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 6, 7 },      id = "gyroLowpass2Frequency" }
 
 labels[#labels + 1] = { t = "Gyro notch 1",             x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Center",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 8, 9 },      id="gyroNotch1Frequency" }
-fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 10, 11 },    id="gyroNotch1Cutoff" }
+fields[#fields + 1] = { t = "Center",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 8, 9 },      id = "gyroNotch1Frequency" }
+fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 10, 11 },    id = "gyroNotch1Cutoff" }
 
 labels[#labels + 1] = { t = "Gyro notch 2",             x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Center",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 12, 13 },    id="gyroNotch2Frequency" }
-fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 14, 15 },    id="gyroNotch2Cutoff" }
+fields[#fields + 1] = { t = "Center",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 12, 13 },    id = "gyroNotch2Frequency" }
+fields[#fields + 1] = { t = "Cutoff",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4000, vals = { 14, 15 },    id = "gyroNotch2Cutoff" }
 
 labels[#labels + 1] = { t = "Dynamic Notch Filters",    x = x,          y = inc.y(lineSpacing) }
 fields[#fields + 1] = { t = "Count",                    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 8, vals = { 20 } }
-fields[#fields + 1] = { t = "Q",                        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 100, vals = { 21 }, scale = 10, id="gyroDynamicNotchQ" }
-fields[#fields + 1] = { t = "Min Frequency",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 200, vals = { 22, 23 },    id="gyroDynamicNotchMinHz" }
+fields[#fields + 1] = { t = "Q",                        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 100, vals = { 21 }, scale = 10, id = "gyroDynamicNotchQ" }
+fields[#fields + 1] = { t = "Min Frequency",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 200, vals = { 22, 23 },    id = "gyroDynamicNotchMinHz" }
 fields[#fields + 1] = { t = "Max Frequency",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 500, vals = { 24, 25 },   id= "gyroDynamicNotchMaxHz"}
 
 return {

--- a/src/SCRIPTS/RF2/PAGES/governor.lua
+++ b/src/SCRIPTS/RF2/PAGES/governor.lua
@@ -14,21 +14,21 @@ local fields = {}
 x = margin
 y = yMinLim - tableSpacing.header
 
-fields[#fields + 1] = { t = "Mode",                x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4,     vals = { 1 }, table = { [0]="OFF", "PASSTHROUGH", "STANDARD", "MODE1", "MODE2" }, id="govMode" }
-fields[#fields + 1] = { t = "Handover throttle%",  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 50,   vals = { 20 },                 id="govHandoverThrottle" }
-fields[#fields + 1] = { t = "Startup time",        x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 600,   vals = { 2,3 }, scale = 10,    id="govStartupTime" }
-fields[#fields + 1] = { t = "Spoolup time",        x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 600,   vals = { 4,5 }, scale = 10,    id="govSpoolupTime" }
-fields[#fields + 1] = { t = "Tracking time",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 6,7 }, scale = 10,    id="govTrackingTime" }
-fields[#fields + 1] = { t = "Recovery time",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 8,9 }, scale = 10,    id="govRecoveryTime" }
-fields[#fields + 1] = { t = "AR bailout time",     x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 16,17 }, scale = 10,  id="govAutoBailoutTime" }
-fields[#fields + 1] = { t = "AR timeout",          x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 14,15 }, scale = 10,  id="govAutoTimeout" }
-fields[#fields + 1] = { t = "AR min entry time",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 18,19 }, scale = 10,  id="govAutoMinEntryTime" }
-fields[#fields + 1] = { t = "Zero throttle TO",    x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 10,11 }, scale = 10,  id="govZeroThrottleTimeout" }
-fields[#fields + 1] = { t = "HS signal timeout",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 12,13 }, scale = 10,  id="govLostHeadspeedTimeout" }
-fields[#fields + 1] = { t = "HS filter cutoff",    x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 22 },                 id="govHeadspeedFilterHz" }
-fields[#fields + 1] = { t = "Volt. filter cutoff", x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 21 },                 id="govVoltageFilterHz" }
-fields[#fields + 1] = { t = "TTA bandwidth",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 23 },                 id="govTTAFilterHz" }
-fields[#fields + 1] = { t = "Precomp bandwidth",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 24 },                 id="govFFFilterHz" }
+fields[#fields + 1] = { t = "Mode",                x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 4,     vals = { 1 }, table = { [0]="OFF", "PASSTHROUGH", "STANDARD", "MODE1", "MODE2" }, id = "govMode" }
+fields[#fields + 1] = { t = "Handover throttle%",  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 50,   vals = { 20 },                 id = "govHandoverThrottle" }
+fields[#fields + 1] = { t = "Startup time",        x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 600,   vals = { 2,3 }, scale = 10,    id = "govStartupTime" }
+fields[#fields + 1] = { t = "Spoolup time",        x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 600,   vals = { 4,5 }, scale = 10,    id = "govSpoolupTime" }
+fields[#fields + 1] = { t = "Tracking time",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 6,7 }, scale = 10,    id = "govTrackingTime" }
+fields[#fields + 1] = { t = "Recovery time",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 8,9 }, scale = 10,    id = "govRecoveryTime" }
+fields[#fields + 1] = { t = "AR bailout time",     x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 16,17 }, scale = 10,  id = "govAutoBailoutTime" }
+fields[#fields + 1] = { t = "AR timeout",          x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 14,15 }, scale = 10,  id = "govAutoTimeout" }
+fields[#fields + 1] = { t = "AR min entry time",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 18,19 }, scale = 10,  id = "govAutoMinEntryTime" }
+fields[#fields + 1] = { t = "Zero throttle TO",    x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 10,11 }, scale = 10,  id = "govZeroThrottleTimeout" }
+fields[#fields + 1] = { t = "HS signal timeout",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100,   vals = { 12,13 }, scale = 10,  id = "govLostHeadspeedTimeout" }
+fields[#fields + 1] = { t = "HS filter cutoff",    x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 22 },                 id = "govHeadspeedFilterHz" }
+fields[#fields + 1] = { t = "Volt. filter cutoff", x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 21 },                 id = "govVoltageFilterHz" }
+fields[#fields + 1] = { t = "TTA bandwidth",       x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 23 },                 id = "govTTAFilterHz" }
+fields[#fields + 1] = { t = "Precomp bandwidth",   x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 24 },                 id = "govFFFilterHz" }
 
 return {
     read        = 142, -- MSP_GOVERNOR_CONFIG

--- a/src/SCRIPTS/RF2/PAGES/mixer.lua
+++ b/src/SCRIPTS/RF2/PAGES/mixer.lua
@@ -12,19 +12,19 @@ local labels = {}
 local fields = {}
 
 labels[#labels + 1] = { t = "Swashplate",               x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Geo correction",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -125,  max = 125,  vals = { 19 }, scale = 5,          id="mixerCollectiveGeoCorrection" }
-fields[#fields + 1] = { t = "Total pitch limit",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0,     max = 3000, vals = { 10, 11 }, scale = 83.33333333333333, mult = 8.3333333333333, id="mixerTotalPitchLimit" }
-fields[#fields + 1] = { t = "Phase angle",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1800, max = 1800, vals = { 8, 9 }, scale = 10, mult = 5, id="mixerSwashPhase" }
+fields[#fields + 1] = { t = "Geo correction",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -125,  max = 125,  vals = { 19 }, scale = 5,          id = "mixerCollectiveGeoCorrection" }
+fields[#fields + 1] = { t = "Total pitch limit",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0,     max = 3000, vals = { 10, 11 }, scale = 83.33333333333333, mult = 8.3333333333333, id = "mixerTotalPitchLimit" }
+fields[#fields + 1] = { t = "Phase angle",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1800, max = 1800, vals = { 8, 9 }, scale = 10, mult = 5, id = "mixerSwashPhase" }
 fields[#fields + 1] = { t = "TTA precomp",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0,     max = 250,  vals = { 18 } }
 
 labels[#labels + 1] = { t = "Swashplate link trims",    x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Roll trim %",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 12, 13 }, scale = 10,    id="mixerSwashRollTrim" }
-fields[#fields + 1] = { t = "Pitch trim %",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 14, 15 }, scale = 10,    id="mixerSwashPitchTrim" }
-fields[#fields + 1] = { t = "Coll. trim %",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 16, 17 }, scale = 10,    id="mixerSwashCollectiveTrim" }
+fields[#fields + 1] = { t = "Roll trim %",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 12, 13 }, scale = 10,    id = "mixerSwashRollTrim" }
+fields[#fields + 1] = { t = "Pitch trim %",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 14, 15 }, scale = 10,    id = "mixerSwashPitchTrim" }
+fields[#fields + 1] = { t = "Coll. trim %",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 16, 17 }, scale = 10,    id = "mixerSwashCollectiveTrim" }
 
 labels[#labels + 1] = { t = "Motorised tail",           x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Motor idle thr%",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0,     max = 250,  vals = { 3 }, scale = 10,         id="mixerTailMotorIdle" }
-fields[#fields + 1] = { t = "Center trim",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -500,  max = 500,  vals = { 4,5 }, scale = 10,       id="mixerTailRotorCenterTrim" }
+fields[#fields + 1] = { t = "Motor idle thr%",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0,     max = 250,  vals = { 3 }, scale = 10,         id = "mixerTailMotorIdle" }
+fields[#fields + 1] = { t = "Center trim",              x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -500,  max = 500,  vals = { 4,5 }, scale = 10,       id = "mixerTailRotorCenterTrim" }
 
 return {
     read        = 42, -- MSP_MIXER_CONFIG

--- a/src/SCRIPTS/RF2/PAGES/profile.lua
+++ b/src/SCRIPTS/RF2/PAGES/profile.lua
@@ -31,54 +31,54 @@ labels[#labels + 1] = { t = "Offset limit",            x = x,          y = inc.y
 fields[#fields + 1] = { t = "Roll",                    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 180, vals = { 37 } }
 fields[#fields + 1] = { t = "Pitch",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 180, vals = { 38 } }
 
-fields[#fields + 1] = { t = "Error rotation",          x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 7 }, table = { [0] = "OFF", "ON" },          id="profilesErrorRotation" }
+fields[#fields + 1] = { t = "Error rotation",          x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1, vals = { 7 }, table = { [0] = "OFF", "ON" }, id = "profilesErrorRotation" }
 
 -- TODO? toggle 'I-term limits', off = 1000
 
-fields[#fields + 1] = { t = "I-term relax type",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 17 }, table = { [0] = "OFF", "RP", "RPY" }, id="profilesItermRelaxType" }
-fields[#fields + 1] = { t = "Cut-off point R",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 18 },  id="profilesItermRelaxCutoffRoll" }
-fields[#fields + 1] = { t = "Cut-off point P",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 19 },  id="profilesItermRelaxCutoffPitch" }
-fields[#fields + 1] = { t = "Cut-off point Y",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 20 },  id="profilesItermRelaxCutoffYaw" }
+fields[#fields + 1] = { t = "I-term relax type",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 17 }, table = { [0] = "OFF", "RP", "RPY" }, id = "profilesItermRelaxType" }
+fields[#fields + 1] = { t = "Cut-off point R",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 18 },  id = "profilesItermRelaxCutoffRoll" }
+fields[#fields + 1] = { t = "Cut-off point P",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 19 },  id = "profilesItermRelaxCutoffPitch" }
+fields[#fields + 1] = { t = "Cut-off point Y",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 20 },  id = "profilesItermRelaxCutoffYaw" }
 
 labels[#labels + 1] = { t = "Yaw",                     x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "CW stop gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 250, vals = { 21 }, id="profilesYawStopGainCW" }
-fields[#fields + 1] = { t = "CCW stop gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 250, vals = { 22 }, id="profilesYawStopGainCCW"}
+fields[#fields + 1] = { t = "CW stop gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 250, vals = { 21 }, id = "profilesYawStopGainCW" }
+fields[#fields + 1] = { t = "CCW stop gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 250, vals = { 22 }, id = "profilesYawStopGainCCW"}
 
-fields[#fields + 1] = { t = "Precomp Cutoff",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 23 },  id="profilesYawPrecompCutoff" }
-fields[#fields + 1] = { t = "Cyclic FF gain",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 24 },  id="profilesYawFFCyclicGain" }
-fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 25 },  id="profilesYawFFCollectiveGain" }
-fields[#fields + 1] = { t = "Col. imp FF gain",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 26 },  id="profilesYawFFImpulseGain" }
-fields[#fields + 1] = { t = "Col. imp FF decay",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 27 },  id="profilesyawFFImpulseDecay" }
+fields[#fields + 1] = { t = "Precomp Cutoff",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 23 },  id = "profilesYawPrecompCutoff" }
+fields[#fields + 1] = { t = "Cyclic FF gain",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 24 },  id = "profilesYawFFCyclicGain" }
+fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 25 },  id = "profilesYawFFCollectiveGain" }
+fields[#fields + 1] = { t = "Col. imp FF gain",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 26 },  id = "profilesYawFFImpulseGain" }
+fields[#fields + 1] = { t = "Col. imp FF decay",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 27 },  id = "profilesyawFFImpulseDecay" }
 
 labels[#labels + 1] = { t = "Pitch",                   x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 28 },  id="profilesPitchFFCollectiveGain" }
+fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 28 },  id = "profilesPitchFFCollectiveGain" }
 
 labels[#labels + 1] = { t = "PID Controller",          x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "R bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 },  id="profilesGyroCutoffRoll" }
-fields[#fields + 1] = { t = "P bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 },  id="profilesGyroCutoffPitch" }
-fields[#fields + 1] = { t = "Y bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 13 },  id="profilesGyroCutoffYaw" }
-fields[#fields + 1] = { t = "R D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 14 },  id="profilesDtermCutoffRoll" }
-fields[#fields + 1] = { t = "P D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 15 },  id="profilesDtermCutoffPitch" }
-fields[#fields + 1] = { t = "Y D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 16 },  id="profilesDtermCutoffYaw" }
-fields[#fields + 1] = { t = "R B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 39 },  id="profilesBtermCutoffRoll" }
-fields[#fields + 1] = { t = "P B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 40 },  id="profilesBtermCutoffPitch" }
-fields[#fields + 1] = { t = "Y B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 41 },  id="profilesBtermCutoffYaw" }
+fields[#fields + 1] = { t = "R bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 },  id = "profilesGyroCutoffRoll" }
+fields[#fields + 1] = { t = "P bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 },  id = "profilesGyroCutoffPitch" }
+fields[#fields + 1] = { t = "Y bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 13 },  id = "profilesGyroCutoffYaw" }
+fields[#fields + 1] = { t = "R D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 14 },  id = "profilesDtermCutoffRoll" }
+fields[#fields + 1] = { t = "P D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 15 },  id = "profilesDtermCutoffPitch" }
+fields[#fields + 1] = { t = "Y D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 16 },  id = "profilesDtermCutoffYaw" }
+fields[#fields + 1] = { t = "R B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 39 },  id = "profilesBtermCutoffRoll" }
+fields[#fields + 1] = { t = "P B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 40 },  id = "profilesBtermCutoffPitch" }
+fields[#fields + 1] = { t = "Y B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 41 },  id = "profilesBtermCutoffYaw" }
 
 labels[#labels + 1] = { t = "Cross coupling",          x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Gain",                    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 34 },  id="profilesCyclicCrossCouplingGain" }
-fields[#fields + 1] = { t = "Ratio",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 35 },  id="profilesCyclicCrossCouplingRatio" }
-fields[#fields + 1] = { t = "Cutoff",                  x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 250, vals = { 36 },  id="profilesCyclicCrossCouplingCutoff" }
+fields[#fields + 1] = { t = "Gain",                    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 34 },  id = "profilesCyclicCrossCouplingGain" }
+fields[#fields + 1] = { t = "Ratio",                   x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 35 },  id = "profilesCyclicCrossCouplingRatio" }
+fields[#fields + 1] = { t = "Cutoff",                  x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 250, vals = { 36 },  id = "profilesCyclicCrossCouplingCutoff" }
 
 labels[#labels + 1] = { t = "Acro trainer",            x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 255, vals = { 32 }, id="profilesAcroTrainerGain" }
-fields[#fields + 1] = { t = "Maximum angle",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 80, vals = { 33 },  id="profilesAcroTrainerLimit" }
+fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 255, vals = { 32 }, id = "profilesAcroTrainerGain" }
+fields[#fields + 1] = { t = "Maximum angle",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 80, vals = { 33 },  id = "profilesAcroTrainerLimit" }
 
 labels[#labels + 1] = { t = "Angle mode",              x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 29 },  id="profilesAngleModeGain" }
-fields[#fields + 1] = { t = "Maximum angle",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 90, vals = { 30 },  id="profilesAngleModeLimit" }
+fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 29 },  id = "profilesAngleModeGain" }
+fields[#fields + 1] = { t = "Maximum angle",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 10, max = 90, vals = { 30 },  id = "profilesAngleModeLimit" }
 
 labels[#labels + 1] = { t = "Horizon mode",            x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 31 },  id="profilesHorizonModeGain" }
+fields[#fields + 1] = { t = "Leveling gain",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 200, vals = { 31 },  id = "profilesHorizonModeGain" }
 
 return {
     read        = 94, -- MSP_PID_PROFILE

--- a/src/SCRIPTS/RF2/PAGES/profile.lua
+++ b/src/SCRIPTS/RF2/PAGES/profile.lua
@@ -35,10 +35,10 @@ fields[#fields + 1] = { t = "Error rotation",          x = x,          y = inc.y
 
 -- TODO? toggle 'I-term limits', off = 1000
 
-fields[#fields + 1] = { t = "I-term relax type",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 17 }, table = { [0] = "OFF", "RP", "RPY" } }
-fields[#fields + 1] = { t = "Cut-off point R",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 18 } }
-fields[#fields + 1] = { t = "Cut-off point P",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 19 } }
-fields[#fields + 1] = { t = "Cut-off point Y",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 20 } }
+fields[#fields + 1] = { t = "I-term relax type",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2, vals = { 17 }, table = { [0] = "OFF", "RP", "RPY" }, id="profilesItermRelaxType" }
+fields[#fields + 1] = { t = "Cut-off point R",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 18 },  id="profilesItermRelaxCutoffRoll" }
+fields[#fields + 1] = { t = "Cut-off point P",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 19 },  id="profilesItermRelaxCutoffPitch" }
+fields[#fields + 1] = { t = "Cut-off point Y",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 100, vals = { 20 },  id="profilesItermRelaxCutoffYaw" }
 
 labels[#labels + 1] = { t = "Yaw",                     x = x,          y = inc.y(lineSpacing) }
 fields[#fields + 1] = { t = "CW stop gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 25, max = 250, vals = { 21 } }
@@ -51,18 +51,18 @@ fields[#fields + 1] = { t = "Col. imp FF gain",        x = x + indent, y = inc.y
 fields[#fields + 1] = { t = "Col. imp FF decay",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 27 } }
 
 labels[#labels + 1] = { t = "Pitch",                   x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 28 } }
+fields[#fields + 1] = { t = "Col. FF gain",            x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 28 },  id="profilesPitchFFCollectiveGain" }
 
 labels[#labels + 1] = { t = "PID Controller",          x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "R bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 } }
-fields[#fields + 1] = { t = "P bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 } }
-fields[#fields + 1] = { t = "Y bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 13 } }
-fields[#fields + 1] = { t = "R D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 14 } }
-fields[#fields + 1] = { t = "P D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 15 } }
-fields[#fields + 1] = { t = "Y D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 16 } }
-fields[#fields + 1] = { t = "R B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 39 } }
-fields[#fields + 1] = { t = "P B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 40 } }
-fields[#fields + 1] = { t = "Y B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 41 } }
+fields[#fields + 1] = { t = "R bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 },  id="profilesGyroCutoffRoll" }
+fields[#fields + 1] = { t = "P bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 },  id="profilesGyroCutoffPitch" }
+fields[#fields + 1] = { t = "Y bandwidth",             x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 13 },  id="profilesGyroCutoffYaw" }
+fields[#fields + 1] = { t = "R D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 14 },  id="profilesDtermCutoffRoll" }
+fields[#fields + 1] = { t = "P D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 15 },  id="profilesDtermCutoffPitch" }
+fields[#fields + 1] = { t = "Y D-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 16 },  id="profilesDtermCutoffYaw" }
+fields[#fields + 1] = { t = "R B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 39 },  id="profilesBtermCutoffRoll" }
+fields[#fields + 1] = { t = "P B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 40 },  id="profilesBtermCutoffPitch" }
+fields[#fields + 1] = { t = "Y B-term cut-off",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 41 },  id="profilesBtermCutoffYaw" }
 
 labels[#labels + 1] = { t = "Cross coupling",          x = x,          y = inc.y(lineSpacing) }
 fields[#fields + 1] = { t = "Gain",                    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 34 } }

--- a/src/SCRIPTS/RF2/PAGES/profile_governor.lua
+++ b/src/SCRIPTS/RF2/PAGES/profile_governor.lua
@@ -11,18 +11,18 @@ local inc = { x = function(val) x = x + val return x end, y = function(val) y = 
 local labels = {}
 local fields = {}
 
-fields[#fields + 1] = { t = "Full headspeed",          x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 1, 2 }, mult = 10, id="govHeadspeed"}
-fields[#fields + 1] = { t = "Max throttle",            x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100, vals = { 13 },  id="govMaxThrottle" }
-fields[#fields + 1] = { t = "PID master gain",         x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 3 },    id="govMasterGain" }
-fields[#fields + 1] = { t = "P-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 4 },    id="govPGain" }
-fields[#fields + 1] = { t = "I-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 5 },    id="govIGain" }
-fields[#fields + 1] = { t = "D-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 6 },    id="govDGain" }
-fields[#fields + 1] = { t = "F-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 7 },    id="govFGain" }
-fields[#fields + 1] = { t = "Yaw precomp.",            x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 10 },   id="govYawPrecomp" }
-fields[#fields + 1] = { t = "Cyclic precomp.",         x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 },   id="govCyclicPrecomp" }
-fields[#fields + 1] = { t = "Col. precomp.",           x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 },   id="govCollectivePrecomp" }
-fields[#fields + 1] = { t = "TTA gain",                x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 8 },    id="govTTAGain" }
-fields[#fields + 1] = { t = "TTA limit",               x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 9 },    id="govTTALimit" }
+fields[#fields + 1] = { t = "Full headspeed",          x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 1, 2 }, mult = 10, id = "govHeadspeed"}
+fields[#fields + 1] = { t = "Max throttle",            x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 100, vals = { 13 },  id = "govMaxThrottle" }
+fields[#fields + 1] = { t = "PID master gain",         x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 3 },    id = "govMasterGain" }
+fields[#fields + 1] = { t = "P-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 4 },    id = "govPGain" }
+fields[#fields + 1] = { t = "I-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 5 },    id = "govIGain" }
+fields[#fields + 1] = { t = "D-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 6 },    id = "govDGain" }
+fields[#fields + 1] = { t = "F-gain",                  x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 7 },    id = "govFGain" }
+fields[#fields + 1] = { t = "Yaw precomp.",            x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 10 },   id = "govYawPrecomp" }
+fields[#fields + 1] = { t = "Cyclic precomp.",         x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 11 },   id = "govCyclicPrecomp" }
+fields[#fields + 1] = { t = "Col. precomp.",           x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 12 },   id = "govCollectivePrecomp" }
+fields[#fields + 1] = { t = "TTA gain",                x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 8 },    id = "govTTAGain" }
+fields[#fields + 1] = { t = "TTA limit",               x = x, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250, vals = { 9 },    id = "govTTALimit" }
 
 return {
     read        = 148, -- MSP_GOVERNOR_PROFILE

--- a/src/SCRIPTS/RF2/PAGES/profile_rescue.lua
+++ b/src/SCRIPTS/RF2/PAGES/profile_rescue.lua
@@ -13,25 +13,25 @@ local fields = {}
 
 --fields[#fields + 1] = { t = "Rescue mode enable",    x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 2,     vals = { 1 }, table = { [0] = "Off", "On", "Alt hold" } }
 fields[#fields + 1] = { t = "Rescue mode enable",    x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1,     vals = { 1 }, table = { [0] = "Off", "On" } }
-fields[#fields + 1] = { t = "Flip to upright",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1,     vals = { 2 }, table = { [0] = "No flip", "Flip" },      id="profilesRescueFlipMode" }
-fields[#fields + 1] = { t = "Pull-up collective",    x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 9,10 }, mult = 10, scale = 10,                 id="profilesRescuePullupCollective" }
-fields[#fields + 1] = { t = "Pull-up time",          x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 5 }, scale = 10,                               id="profilesRescuePullupTime" }
-fields[#fields + 1] = { t = "Climb collective",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 11,12 }, mult = 10, scale = 10,                id="profilesRescueClimbCollective" }
-fields[#fields + 1] = { t = "Climb time",            x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 6 }, scale = 10,                               id="profilesRescueClimbTime" }
-fields[#fields + 1] = { t = "Hover collective",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 13,14 }, mult = 10, scale = 10,                id="profilesRescueHoverCollective" }
-fields[#fields + 1] = { t = "Flip fail time",        x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 7 }, scale = 10,                               id="profilesRescueFlipTime" }
-fields[#fields + 1] = { t = "Exit time",             x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 8 }, scale = 10,                               id="profilesRescueExitTime" }
-fields[#fields + 1] = { t = "Rescue level gain",     x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 5, max = 250,   vals = { 4 },                                           id="profilesRescueLevelGain" }
-fields[#fields + 1] = { t = "Rescue flip gain",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 5, max = 250,   vals = { 3 },                                           id="profilesRescueFlipGain" }
-fields[#fields + 1] = { t = "Rescue max rate",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 1000,  vals = { 25,26 }, mult = 10,                            id="profilesRescueMaxRate" }
-fields[#fields + 1] = { t = "Rescue max accel",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 10000, vals = { 27,28 }, mult = 10,                            id="profilesRescueMaxAccel" }
+fields[#fields + 1] = { t = "Flip to upright",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1,     vals = { 2 }, table = { [0] = "No flip", "Flip" },      id = "profilesRescueFlipMode" }
+fields[#fields + 1] = { t = "Pull-up collective",    x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 9,10 }, mult = 10, scale = 10,                 id = "profilesRescuePullupCollective" }
+fields[#fields + 1] = { t = "Pull-up time",          x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 5 }, scale = 10,                               id = "profilesRescuePullupTime" }
+fields[#fields + 1] = { t = "Climb collective",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 11,12 }, mult = 10, scale = 10,                id = "profilesRescueClimbCollective" }
+fields[#fields + 1] = { t = "Climb time",            x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 6 }, scale = 10,                               id = "profilesRescueClimbTime" }
+fields[#fields + 1] = { t = "Hover collective",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 1000,  vals = { 13,14 }, mult = 10, scale = 10,                id = "profilesRescueHoverCollective" }
+fields[#fields + 1] = { t = "Flip fail time",        x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 7 }, scale = 10,                               id = "profilesRescueFlipTime" }
+fields[#fields + 1] = { t = "Exit time",             x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 8 }, scale = 10,                               id = "profilesRescueExitTime" }
+fields[#fields + 1] = { t = "Rescue level gain",     x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 5, max = 250,   vals = { 4 },                                           id = "profilesRescueLevelGain" }
+fields[#fields + 1] = { t = "Rescue flip gain",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 5, max = 250,   vals = { 3 },                                           id = "profilesRescueFlipGain" }
+fields[#fields + 1] = { t = "Rescue max rate",       x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 1000,  vals = { 25,26 }, mult = 10,                            id = "profilesRescueMaxRate" }
+fields[#fields + 1] = { t = "Rescue max accel",      x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 10000, vals = { 27,28 }, mult = 10,                            id = "profilesRescueMaxAccel" }
 --[[
 labels[#labels + 1] = { t = "Altitude hold",         x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Hover altitude",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 15,16 }, mult = 10, scale = 100,               id="profilesRescueHoverAltitude" }
-fields[#fields + 1] = { t = "P-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 17,18 },                                       id="profilesRescueAltitudePGain" }
-fields[#fields + 1] = { t = "I-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 19,20 },                                       id="profilesRescueAltitudeIGain" }
-fields[#fields + 1] = { t = "D-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 21,22 },                                       id="profilesRescueAltitudeDGain" }
-fields[#fields + 1] = { t = "Max collective",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 1000,  vals = { 23,24 }, mult = 10, scale = 10,                id="profilesRescueMaxCollective" }
+fields[#fields + 1] = { t = "Hover altitude",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 15,16 }, mult = 10, scale = 100,               id = "profilesRescueHoverAltitude" }
+fields[#fields + 1] = { t = "P-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 17,18 },                                       id = "profilesRescueAltitudePGain" }
+fields[#fields + 1] = { t = "I-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 19,20 },                                       id = "profilesRescueAltitudeIGain" }
+fields[#fields + 1] = { t = "D-gain",                x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 10000, vals = { 21,22 },                                       id = "profilesRescueAltitudeDGain" }
+fields[#fields + 1] = { t = "Max collective",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 1, max = 1000,  vals = { 23,24 }, mult = 10, scale = 10,                id = "profilesRescueMaxCollective" }
 --]]
 
 return {

--- a/src/SCRIPTS/RF2/PAGES/rates.lua
+++ b/src/SCRIPTS/RF2/PAGES/rates.lua
@@ -52,17 +52,17 @@ fields[#fields + 1] = { t = "Rates Type",          x = x,          y = inc.y(lin
 inc.y(lineSpacing*0.4)
 
 labels[#labels + 1] = { t = "Roll dynamics",       x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 5 },                     id="rateSetupResponse"  }
-fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 6,7 },   scale = 0.1,    id="rateSetupAcceleration" }
+fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 5 },                     id = "rateSetupResponse"  }
+fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 6,7 },   scale = 0.1,    id = "rateSetupAcceleration" }
 labels[#labels + 1] = { t = "Pitch dynamics",      x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 11 } ,                   id="rateSetupResponse" }
-fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 12,13 }, scale = 0.1,    id="rateSetupAcceleration" }
+fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 11 } ,                   id = "rateSetupResponse" }
+fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 12,13 }, scale = 0.1,    id = "rateSetupAcceleration" }
 labels[#labels + 1] = { t = "Yaw dynamics",        x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 17 },                    id="rateSetupResponse"  }
-fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 18,19 }, scale = 0.1,    id="rateSetupAcceleration" }
+fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 17 },                    id = "rateSetupResponse"  }
+fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 18,19 }, scale = 0.1,    id = "rateSetupAcceleration" }
 labels[#labels + 1] = { t = "Collective dynamics", x = x,          y = inc.y(lineSpacing) }
-fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 23 },                    id="rateSetupResponse" }
-fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 24,25 }, scale = 0.1,    id="rateSetupAcceleration" }
+fields[#fields + 1] = { t = "Response time",       x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 250,   vals = { 23 },                    id = "rateSetupResponse" }
+fields[#fields + 1] = { t = "Max acceleration",    x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 50000, vals = { 24,25 }, scale = 0.1,    id = "rateSetupAcceleration" }
 
 return {
     read        = 111, -- MSP_RC_TUNING

--- a/src/SCRIPTS/RF2/PAGES/servos.lua
+++ b/src/SCRIPTS/RF2/PAGES/servos.lua
@@ -12,13 +12,13 @@ local labels = {}
 local fields = {}
 
 fields[#fields + 1] = { t = "Servo",         x = x,          y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 7, vals = { 1 }, table = { [0] = "ELEVATOR", "CYCL L", "CYCL R", "TAIL" }, postEdit = function(self, page) self.servoChanged(page) end }
-fields[#fields + 1] = { t = "Center",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 50, max = 2250, vals = { 2,3 },     id="servoMid" }
-fields[#fields + 1] = { t = "Min",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 4,5 },  id="servoMin" }
-fields[#fields + 1] = { t = "Max",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 6,7 },  id="servoMax" }
-fields[#fields + 1] = { t = "Scale neg",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 1000, vals = { 8,9 },    id="servoScaleNeg" }
-fields[#fields + 1] = { t = "Scale pos",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 1000, vals = { 10,11 },  id="servoScalePos" }
-fields[#fields + 1] = { t = "Rate",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 50, max = 5000, vals = { 12,13 },   id="servoRate" }
-fields[#fields + 1] = { t = "Speed",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 60000, vals = { 14,15 },   id="servoSpeed" }
+fields[#fields + 1] = { t = "Center",        x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 50, max = 2250, vals = { 2,3 },     id = "servoMid" }
+fields[#fields + 1] = { t = "Min",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 4,5 },  id = "servoMin" }
+fields[#fields + 1] = { t = "Max",           x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = -1000, max = 1000, vals = { 6,7 },  id = "servoMax" }
+fields[#fields + 1] = { t = "Scale neg",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 1000, vals = { 8,9 },    id = "servoScaleNeg" }
+fields[#fields + 1] = { t = "Scale pos",     x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 100, max = 1000, vals = { 10,11 },  id = "servoScalePos" }
+fields[#fields + 1] = { t = "Rate",          x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 50, max = 5000, vals = { 12,13 },   id = "servoRate" }
+fields[#fields + 1] = { t = "Speed",         x = x + indent, y = inc.y(lineSpacing), sp = x + sp, min = 0, max = 60000, vals = { 14,15 },   id = "servoSpeed" }
 
 return {
     read        = 120, -- MSP_SERVO_CONFIGURATIONS


### PR DESCRIPTION
add correlation id between lua fields to configurator (messages.json),
so we can have help string and units on the up coming color-screen lua script