### PR TITLE
Fix GPS coordinates on EdgeTX under custom CRSF telemetry

### DIFF
--- a/src/SCRIPTS/MIXES/rf2tlm.lua
+++ b/src/SCRIPTS/MIXES/rf2tlm.lua
@@ -109,12 +109,14 @@ local function decAccel(data, pos)
 end
 
 local function decLatLong(data, pos)
+    local UNIT_GPS_LONGITUDE = 43
+    local UNIT_GPS_LATITUDE = 44
     local lat,lon
     lat,pos = decS32(data,pos)
     lon,pos = decS32(data,pos)
     setTelemetryValue(0x1125, 0, 0, 0, UNIT_GPS, 0, "GPS")
-    setTelemetryValue(0x1125, 0, 0, lat, UNIT_GPS_LATITUDE)
-    setTelemetryValue(0x1125, 0, 0, lon, UNIT_GPS_LONGITUDE)
+    setTelemetryValue(0x1125, 0, 0, lat/10, UNIT_GPS_LATITUDE)
+    setTelemetryValue(0x1125, 0, 0, lon/10, UNIT_GPS_LONGITUDE)
     return nil, pos
 end
 


### PR DESCRIPTION
GPS coordinates do not populate (sensor displays zero coordinates) when using custom CRSF telemetry on EdgeTX w/ Radiomaster TX16S (see #72).

This may be a similar issue to [the issue discussed in this openrcforums post](https://openrcforums.com/forum/viewtopic.php?t=11531). UNIT_GPS_LONGITUDE and UNIT_GPS_LATITUDE are not defined in lua, at least for this EdgeTX version.

Defining UNIT_GPS_LONGITUDE and UNIT_GPS_LATITUDE locally in [decLatLong()](https://github.com/rotorflight/rotorflight-lua-scripts/blob/6add88e39436c14e95d3e3ca97f5e209be6659ae/src/SCRIPTS/MIXES/rf2tlm.lua#L111) based on unit declarations in [EdgeTX source file dataconstants.h](https://github.com/EdgeTX/edgetx/blob/366df6080e915aa5ee76fe58e751aa013849f0e2/radio/src/dataconstants.h#L330) results in display of GPS coordinate values, though they are scaled up by a factor of 10. Manually dividing the values by 10 corrects the fault.

This author has not tested the proposed fix on transmitter hardware other than the aforementioned TX16s, and cannot explain the origin of the 10X scaling issue.

This PR was created at express request of the project owner at https://github.com/rotorflight/rotorflight-lua-scripts/issues/72#issuecomment-2465215361. 
