### PR TITLE
Render unscaled values as an integer

### DIFF
--- a/src/SCRIPTS/RF2/ui.lua
+++ b/src/SCRIPTS/RF2/ui.lua
@@ -329,6 +329,9 @@ local function drawScreen()
             end
         elseif f.value then
             val = f.value
+            if type(val) == "number" and not f.scale then
+                val = math.floor(val)
+            end
             if f.table and f.table[f.value] then
                 val = f.table[f.value]
             end

--- a/src/SCRIPTS/RF2/ui.lua
+++ b/src/SCRIPTS/RF2/ui.lua
@@ -318,7 +318,11 @@ local function drawScreen()
         if f.data and f.data.value then
             val = f.data.value
             if type(val) == "number" then
-                val = val / (f.data.scale or 1)
+                if f.data.scale then
+                    val = val / f.data.scale
+                else
+                    val = math.floor(val)
+                end
             end
             if f.data.table and f.data.table[val] then
                 val = f.data.table[val]


### PR DESCRIPTION
EdgeTX 2.11 uses Lua 5.3, which has separate internal types for floats and integers. Now when a whole number float is converted to a string it has a trailing `.0`. This change explicitly converts unscaled fields to an integer before rendering.