### PR TITLE
Fix rates page integers showing decimal place

### DIFF
--- a/src/SCRIPTS/RF2/ui.lua
+++ b/src/SCRIPTS/RF2/ui.lua
@@ -275,7 +275,8 @@ local function drawScreen()
             if type(val) == "number" then
                 if f.data.scale then
                     val = val / f.data.scale
-                else
+                end
+                if (f.data.scale or 1) <= 1 then
                     val = math.floor(val)
                 end
             end


### PR DESCRIPTION
`scale` can be less than 1 to create larger integer values. These need to be `floor`ed to render correctly with Lua 5.3. This can be seen on the rates page.