### PR TITLE
Use fallback model name when not connected

### DIFF
--- a/src/SCRIPTS/RF2/background_init.lua
+++ b/src/SCRIPTS/RF2/background_init.lua
@@ -3,6 +3,7 @@ local crsfCustomTelemetryEnabled = false
 
 local settingsHelper = assert(rf2.loadScript(rf2.baseDir.."PAGES/helpers/settingsHelper.lua"))()
 local autoSetName = settingsHelper.loadSettings().autoSetName == 1 or false
+local fallbackModelName = "ROTORFLIGHT"
 settingsHelper = nil
 
 local pilotConfigSetMagic = -765
@@ -135,7 +136,11 @@ local function initializeQueue()
                 rf2.useApi("mspName").getModelName(
                     function(_, name)
                         local info = model.getInfo()
-                        info.name = name
+                        if name and #name > 0 then
+                            info.name = name
+                        else
+                            info.name = fallbackModelName
+                        end
                         model.setInfo(info)
                     end)
             end
@@ -168,6 +173,12 @@ local function initialize(modelIsConnected)
     end
 
     if not modelIsConnected then
+        if autoSetName then
+            local info = model.getInfo()
+            info.name = fallbackModelName
+            model.setInfo(info)
+        end
+
         return false
     end
 

--- a/src/SCRIPTS/RF2/background_init.lua
+++ b/src/SCRIPTS/RF2/background_init.lua
@@ -3,7 +3,6 @@ local crsfCustomTelemetryEnabled = false
 
 local settingsHelper = assert(rf2.loadScript(rf2.baseDir.."PAGES/helpers/settingsHelper.lua"))()
 local autoSetName = settingsHelper.loadSettings().autoSetName == 1 or false
-local fallbackModelName = "ROTORFLIGHT"
 settingsHelper = nil
 
 local pilotConfigSetMagic = -765
@@ -122,6 +121,16 @@ local function waitForCustomSensorsDiscovery()
     return 0
 end
 
+local function setModelName(name)
+    local newName =  ">" .. ((name and #name > 0) and name or "Rotorflight")
+    local info = model.getInfo()
+    if info.name == newName then
+        return
+    end
+    info.name = newName
+    model.setInfo(info)
+end
+
 local queueInitialized = false
 local function initializeQueue()
     --rf2.print("Initializing MSP queue")
@@ -135,13 +144,7 @@ local function initializeQueue()
             if autoSetName then
                 rf2.useApi("mspName").getModelName(
                     function(_, name)
-                        local info = model.getInfo()
-                        if name and #name > 0 then
-                            info.name = name
-                        else
-                            info.name = fallbackModelName
-                        end
-                        model.setInfo(info)
+                        setModelName(name)
                     end)
             end
 
@@ -174,9 +177,7 @@ local function initialize(modelIsConnected)
 
     if not modelIsConnected then
         if autoSetName then
-            local info = model.getInfo()
-            info.name = fallbackModelName
-            model.setInfo(info)
+            setModelName(nil)
         end
 
         return false


### PR DESCRIPTION
Sets the model name to ">Rotorflight" when a model is not connected, or the model does not have a name.
Sets the model name to ">modelname" when a model is connected.
Reason for prepending the ">": this way the model keeps the same position in the list of models.
