### PR TITLE
feat: added flight statistics to Model page

### DIFF
--- a/src/SCRIPTS/RF2/COMPILE/scripts.lua
+++ b/src/SCRIPTS/RF2/COMPILE/scripts.lua
@@ -29,6 +29,7 @@ local scripts = {
     "/SCRIPTS/RF2/MSP/mspExperimental.lua",
     "/SCRIPTS/RF2/MSP/mspFeatureConfig.lua",
     "/SCRIPTS/RF2/MSP/mspFilterConfig.lua",
+    "/SCRIPTS/RF2/MSP/mspFlightStats.lua",
     "/SCRIPTS/RF2/MSP/mspGovernorConfig.lua",
     "/SCRIPTS/RF2/MSP/mspHelper.lua",
     "/SCRIPTS/RF2/MSP/mspMixer.lua",

--- a/src/SCRIPTS/RF2/LVGL/page.lua
+++ b/src/SCRIPTS/RF2/LVGL/page.lua
@@ -55,6 +55,27 @@ local function show(page)
                     if field.preEdit then field.preEdit(field, page) end
                 end,
             }
+        elseif field.data and field.data.value and type(field.data.value) == "string" then
+            local child
+            if field.readOnly then
+                child = {
+                    type = "label",
+                    x = field.sp or field.x,
+                    y = field.y + 3,
+                    text = field.data.value,
+                }
+            else
+                child = {
+                    type = "textEdit",
+                    x = field.sp or field.x,
+                    y = field.y,
+                    w = field.w or 125,
+                    value = field.data.value,
+                    length = field.data.max or 10,
+                }
+            end
+
+            children[#children + 1] = child
         elseif field.data and field.data.value and type(field.data.value) == "number" then
             local child
             if field.readOnly then

--- a/src/SCRIPTS/RF2/MSP/mspApiVersion.lua
+++ b/src/SCRIPTS/RF2/MSP/mspApiVersion.lua
@@ -7,7 +7,7 @@ local function getApiVersion(callback, callbackParam)
                 callback(callbackParam, version)
             end
         end,
-        simulatorResponse = { 0, 12, 8 }
+        simulatorResponse = { 0, 12, 9 }
     }
     rf2.mspQueue:add(message)
 end

--- a/src/SCRIPTS/RF2/MSP/mspFlightStats.lua
+++ b/src/SCRIPTS/RF2/MSP/mspFlightStats.lua
@@ -1,0 +1,47 @@
+local function getDefaults()
+    local defaults = {}
+    defaults.stats_total_flights = { min = 0, max = 2147483647 } -- Actual max is 4294967295, but EdgeTX doesn't support unsigned longs.
+    defaults.stats_total_time_s = { min = 0, max = 2147483647, unit = rf2.units.seconds }
+    defaults.stats_total_dist_m = { min = 0, max = 2147483647, unit = rf2.units.meters }
+    defaults.stats_min_armed_time_s = { min = -1, max = 127, unit = rf2.units.seconds }
+    -- Calculated fields
+    defaults.statsEnabled = { min = 0, max = 1, table = { [0] = "Off", "On" } }
+    return defaults
+end
+
+local function getFlightStats(callback, callbackParam, config)
+    if not config then config = getDefaults() end
+    local message = {
+        command = 14, -- MSP_FLIGHT_STATS, introduced in MSP API 12.9
+        processReply = function(self, buf)
+            config.stats_total_flights.value = rf2.mspHelper.readU32(buf)
+            config.stats_total_time_s.value = rf2.mspHelper.readU32(buf)
+            config.stats_total_dist_m.value = rf2.mspHelper.readU32(buf)
+            config.stats_min_armed_time_s.value = rf2.mspHelper.readS8(buf)
+            -- Calculated fields
+            config.statsEnabled.value = config.stats_min_armed_time_s.value ~= -1 and 1 or 0
+            if callback then callback(callbackParam, config) end
+        end,
+        simulatorResponse = { 123,1,0,0, 100,1,2,0, 0,0,0,0, 15}
+    }
+    rf2.mspQueue:add(message)
+end
+
+local function setFlightStats(config)
+    local message = {
+        command = 15, -- MSP_SET_FLIGHT_STATS, introduced in MSP API 12.9
+        payload = {},
+        simulatorResponse = {}
+    }
+    rf2.mspHelper.writeU32(message.payload, config.stats_total_flights.value)
+    rf2.mspHelper.writeU32(message.payload, config.stats_total_time_s.value)
+    rf2.mspHelper.writeU32(message.payload, config.stats_total_dist_m.value)
+    rf2.mspHelper.writeU8(message.payload, config.stats_min_armed_time_s.value)
+    rf2.mspQueue:add(message)
+end
+
+return {
+    read = getFlightStats,
+    write = setFlightStats,
+    getDefaults = getDefaults
+}

--- a/src/SCRIPTS/RF2/MSP/mspPilotConfig.lua
+++ b/src/SCRIPTS/RF2/MSP/mspPilotConfig.lua
@@ -23,7 +23,7 @@ end
 local function getPilotConfig(callback, callbackParam, config)
     if not config then config = getDefaults() end
     local message = {
-        command = 12, -- MSP_PILOT_CONFIG
+        command = 12, -- MSP_PILOT_CONFIG, introduced in MSP API 12.7
         processReply = function(self, buf)
             config.model_id.value = rf2.mspHelper.readU8(buf)
             config.model_param1_type.value = rf2.mspHelper.readU8(buf)
@@ -35,23 +35,17 @@ local function getPilotConfig(callback, callbackParam, config)
             if rf2.apiVersion >= 12.09 then
                 config.model_flags.value = rf2.mspHelper.readU32(buf)
                 --rf2.print("model_flags: " .. tostring(config.model_flags.value))
-                config.stats_total_flights.value = rf2.mspHelper.readU32(buf)
-                config.stats_total_time_s.value = rf2.mspHelper.readU32(buf)
-                config.stats_total_dist_m.value = rf2.mspHelper.readU32(buf)
-                config.stats_min_armed_time_s.value = rf2.mspHelper.readS8(buf)
-                -- Calculated fields
-                config.statsEnabled.value = config.stats_min_armed_time_s.value ~= -1 and 1 or 0
             end
-            callback(callbackParam, config)
+            if callback then callback(callbackParam, config) end
         end,
-        simulatorResponse = { 21, 1,240,0, 0,0,0, 0,0,0, 2,0,0,0, 10,0,0,0, 100,0,0,0, 0,0,0,0, 10}
+        simulatorResponse = { 21,  1,240,0,  0,0,0,  0,0,0,  2,0,0,0 }
     }
     rf2.mspQueue:add(message)
 end
 
 local function setPilotConfig(config)
     local message = {
-        command = 13, -- MSP_SET_PILOT_CONFIG
+        command = 13, -- MSP_SET_PILOT_CONFIG, introduced in MSP API 12.7
         payload = {},
         simulatorResponse = {}
     }
@@ -65,10 +59,6 @@ local function setPilotConfig(config)
     if rf2.apiVersion >= 12.09 then
         --rf2.print("model_flags: " .. tostring(config.model_flags.value))
         rf2.mspHelper.writeU32(message.payload, config.model_flags.value)
-        rf2.mspHelper.writeU32(message.payload, config.stats_total_flights.value)
-        rf2.mspHelper.writeU32(message.payload, config.stats_total_time_s.value)
-        rf2.mspHelper.writeU32(message.payload, config.stats_total_dist_m.value)
-        rf2.mspHelper.writeU8(message.payload, config.stats_min_armed_time_s.value)
     end
     rf2.mspQueue:add(message)
 end

--- a/src/SCRIPTS/RF2/MSP/mspPilotConfig.lua
+++ b/src/SCRIPTS/RF2/MSP/mspPilotConfig.lua
@@ -9,6 +9,7 @@ local function getDefaults()
     defaults.model_param3_type = { min = 0, max = #paramTypes, table = paramTypes }
     defaults.model_param3_value = { min = -32000, max = 32000 }
     if rf2.apiVersion >= 12.09 then
+        defaults.model_flags = { MODEL_SET_NAME = 0, MODEL_TELL_CAPACITY = 1 } -- see pg/pilot.h
         defaults.stats_total_flights = { min = 0, max = 2147483647 } -- Actual max is 4294967295, but EdgeTX doesn't support unsigned longs.
         defaults.stats_total_time_s = { min = 0, max = 2147483647, unit = rf2.units.seconds }
         defaults.stats_total_dist_m = { min = 0, max = 2147483647, unit = rf2.units.meters }
@@ -32,6 +33,8 @@ local function getPilotConfig(callback, callbackParam, config)
             config.model_param3_type.value = rf2.mspHelper.readU8(buf)
             config.model_param3_value.value = rf2.mspHelper.readS16(buf)
             if rf2.apiVersion >= 12.09 then
+                config.model_flags.value = rf2.mspHelper.readU32(buf)
+                --rf2.print("model_flags: " .. tostring(config.model_flags.value))
                 config.stats_total_flights.value = rf2.mspHelper.readU32(buf)
                 config.stats_total_time_s.value = rf2.mspHelper.readU32(buf)
                 config.stats_total_dist_m.value = rf2.mspHelper.readU32(buf)
@@ -41,7 +44,7 @@ local function getPilotConfig(callback, callbackParam, config)
             end
             callback(callbackParam, config)
         end,
-        simulatorResponse = { 21,  1, 240, 0,  0, 0, 0,  0, 0, 0,  10,0,0,0,  100,0,0,0,  0,0,0,0,  10}
+        simulatorResponse = { 21, 1,240,0, 0,0,0, 0,0,0, 2,0,0,0, 10,0,0,0, 100,0,0,0, 0,0,0,0, 10}
     }
     rf2.mspQueue:add(message)
 end
@@ -60,6 +63,8 @@ local function setPilotConfig(config)
     rf2.mspHelper.writeU8(message.payload, config.model_param3_type.value)
     rf2.mspHelper.writeU16(message.payload, config.model_param3_value.value)
     if rf2.apiVersion >= 12.09 then
+        --rf2.print("model_flags: " .. tostring(config.model_flags.value))
+        rf2.mspHelper.writeU32(message.payload, config.model_flags.value)
         rf2.mspHelper.writeU32(message.payload, config.stats_total_flights.value)
         rf2.mspHelper.writeU32(message.payload, config.stats_total_time_s.value)
         rf2.mspHelper.writeU32(message.payload, config.stats_total_dist_m.value)

--- a/src/SCRIPTS/RF2/PAGES/model.lua
+++ b/src/SCRIPTS/RF2/PAGES/model.lua
@@ -13,30 +13,73 @@ local labels = {}
 local fields = {}
 local pilotConfig = rf2.useApi("mspPilotConfig").getDefaults()
 local settings = settingsHelper.loadSettings()
+local modelName = "---"
 
-x = margin
-y = yMinLim - tableSpacing.header
+--if rf2.statsEnabled == nil then rf2.statsEnabled = false end
 
-labels[1] = { t = "---",                    x = x, y = incY(lineSpacing) }
+-- local function onStatisticsEnabled(self, page)
+--     rf2.useApi("mspRcTuning").getRateDefaults(rcTuning, rcTuning.rates_type.value)
+--     rebuildForm(self)
+--     rf2.onPageReady(page)
+-- end
 
-incY(lineSpacing * 0.25)
-fields[1] = { t = "Set name on TX",         x = x, y = incY(lineSpacing), sp = x + sp, data = { value = settings.autoSetName or 0, min = 0, max = 1, table = { [0] = "Off", "On" } } }
-labels[2] = { t = "Note: requires rf2bg",   x = x + indent, y = incY(lineSpacing) }
+local function buildForm(page)
+    page.labels = nil
+    page.fields = nil
+    labels = {}
+    fields = {}
+    collectgarbage()
 
-incY(lineSpacing * 0.25)
-fields[#fields + 1] = { t = "Model ID",     x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_id }
-fields[#fields + 1] = { t = "Param1 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_type }
-fields[#fields + 1] = { t = "Param1 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_value }
-fields[#fields + 1] = { t = "Param2 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_type }
-fields[#fields + 1] = { t = "Param2 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_value }
-fields[#fields + 1] = { t = "Param3 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_type }
-fields[#fields + 1] = { t = "Param3 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_value }
+    x = margin
+    y = yMinLim - tableSpacing.header
+
+    labels[1] = { t = modelName,                    x = x, y = incY(lineSpacing) }
+
+    incY(lineSpacing * 0.25)
+    fields[1] = { t = "Set name on TX",         x = x, y = incY(lineSpacing), sp = x + sp, data = { value = settings.autoSetName or 0, min = 0, max = 1, table = { [0] = "Off", "On" } } }
+    labels[2] = { t = "Note: requires rf2bg",   x = x + indent, y = incY(lineSpacing) }
+
+    incY(lineSpacing * 0.25)
+    fields[#fields + 1] = { t = "Model ID",     x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_id }
+    fields[#fields + 1] = { t = "Param1 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_type }
+    fields[#fields + 1] = { t = "Param1 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_value }
+    fields[#fields + 1] = { t = "Param2 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_type }
+    fields[#fields + 1] = { t = "Param2 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_value }
+    fields[#fields + 1] = { t = "Param3 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_type }
+    fields[#fields + 1] = { t = "Param3 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_value }
+
+    if rf2.apiVersion >= 12.09 then
+        incY(lineSpacing * 0.25)
+        labels[3] = { t = "Statistics",                   x = x, y = incY(lineSpacing) }
+        fields[#fields + 1] = { t = "Enabled",            x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.statsEnabled,
+            postEdit = function(self, page)
+                if self.data.value == 0 then
+                    pilotConfig.stats_min_armed_time_s.value = -1
+                else
+                    pilotConfig.stats_min_armed_time_s.value = 15
+                end
+                buildForm(page)
+                rf2.onPageReady(page)
+            end
+        }
+        if pilotConfig.statsEnabled.value and pilotConfig.statsEnabled.value == 1 then
+            fields[#fields + 1] = { t = "Min armed time", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_min_armed_time_s }
+            fields[#fields + 1] = { t = "Total flights",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_flights }
+            fields[#fields + 1] = { t = "Total time",     x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_time_s }
+            fields[#fields + 1] = { t = "Total distance", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_dist_m }
+        end
+    end
+
+    page.labels = labels
+    page.fields = fields
+end
 
 local function onReceivedModelName(page, name)
-    labels[1].t = name
+    modelName = name
 end
 
 local function onReceivedPilotConfig(page, config)
+    buildForm(page)
     rf2.onPageReady(page)
 end
 
@@ -47,6 +90,7 @@ end
 
 return {
     read = function(self)
+        --buildForm(self)
         rf2.useApi("mspName").getModelName(onReceivedModelName, self)
         rf2.useApi("mspPilotConfig").read(onReceivedPilotConfig, self, pilotConfig)
     end,

--- a/src/SCRIPTS/RF2/PAGES/model.lua
+++ b/src/SCRIPTS/RF2/PAGES/model.lua
@@ -14,14 +14,7 @@ local fields = {}
 local pilotConfig = rf2.useApi("mspPilotConfig").getDefaults()
 local settings = settingsHelper.loadSettings()
 local modelName = "---"
-
---if rf2.statsEnabled == nil then rf2.statsEnabled = false end
-
--- local function onStatisticsEnabled(self, page)
---     rf2.useApi("mspRcTuning").getRateDefaults(rcTuning, rcTuning.rates_type.value)
---     rebuildForm(self)
---     rf2.onPageReady(page)
--- end
+local setNameOnTxFieldIndex
 
 local function buildForm(page)
     page.labels = nil
@@ -33,24 +26,12 @@ local function buildForm(page)
     x = margin
     y = yMinLim - tableSpacing.header
 
-    labels[1] = { t = modelName,                    x = x, y = incY(lineSpacing) }
-
-    incY(lineSpacing * 0.25)
-    fields[1] = { t = "Set name on TX",         x = x, y = incY(lineSpacing), sp = x + sp, data = { value = settings.autoSetName or 0, min = 0, max = 1, table = { [0] = "Off", "On" } } }
-    labels[2] = { t = "Note: requires rf2bg",   x = x + indent, y = incY(lineSpacing) }
-
-    incY(lineSpacing * 0.25)
+    labels[#labels + 1] = { t = modelName,      x = x, y = incY(lineSpacing) }
     fields[#fields + 1] = { t = "Model ID",     x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_id }
-    fields[#fields + 1] = { t = "Param1 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_type }
-    fields[#fields + 1] = { t = "Param1 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_value }
-    fields[#fields + 1] = { t = "Param2 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_type }
-    fields[#fields + 1] = { t = "Param2 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_value }
-    fields[#fields + 1] = { t = "Param3 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_type }
-    fields[#fields + 1] = { t = "Param3 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_value }
 
     if rf2.apiVersion >= 12.09 then
-        incY(lineSpacing * 0.25)
-        labels[3] = { t = "Statistics",                   x = x, y = incY(lineSpacing) }
+        incY(lineSpacing * 0.5)
+        labels[#labels + 1] = { t = "Statistics",         x = x, y = incY(lineSpacing) }
         fields[#fields + 1] = { t = "Enabled",            x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.statsEnabled,
             postEdit = function(self, page)
                 if self.data.value == 0 then
@@ -63,12 +44,55 @@ local function buildForm(page)
             end
         }
         if pilotConfig.statsEnabled.value and pilotConfig.statsEnabled.value == 1 then
+            fields[#fields + 1] = { t = "Total flights",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_flights, readOnly = true }
+
+            local formatSeconds = function(seconds)
+                local days = math.floor(seconds / 86400)
+                seconds = seconds % 86400
+                local hours = math.floor(seconds / 3600)
+                seconds = seconds % 3600
+                local minutes = math.floor(seconds / 60)
+                seconds = seconds % 60
+
+                local s = string.format("%02d:%02d:%02d", hours, minutes, seconds)
+                if days > 0 then
+                    -- e.g. 12d04:30:58
+                    return string.format("%dd%s", days, s)
+                else
+                    -- only 04:30:58
+                    return s
+                end
+            end
+            local totalTime = formatSeconds(pilotConfig.stats_total_time_s.value)
+            fields[#fields + 1] = { t = "Total time",     x = x, y = incY(lineSpacing), sp = x + sp, data = { value = totalTime }, readOnly = true  }
+
+            fields[#fields + 1] = { t = "Total distance", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_dist_m, readOnly = true  }
             fields[#fields + 1] = { t = "Min armed time", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_min_armed_time_s }
-            fields[#fields + 1] = { t = "Total flights",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_flights }
-            fields[#fields + 1] = { t = "Total time",     x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_time_s }
-            fields[#fields + 1] = { t = "Total distance", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.stats_total_dist_m }
+
+            local function resetStats(self, page)
+                pilotConfig.stats_total_flights.value = 0
+                pilotConfig.stats_total_time_s.value = 0
+                pilotConfig.stats_total_dist_m.value = 0
+                buildForm(page)
+                rf2.onPageReady(page)
+            end
+            fields[#fields + 1] = { t = "[Reset Stats]",  x = x + indent * 3, y = incY(lineSpacing * 1.3), preEdit = resetStats }
         end
     end
+
+    incY(lineSpacing * 0.5)
+    labels[#labels + 1] = { t = "Radio Configuration",       x = x, y = incY(lineSpacing) }
+    labels[#labels + 1] = { t = "Note: requires rf2bg",   x = x + indent, y = incY(lineSpacing), bold = false }
+    incY(lineSpacing * 0.25)
+    setNameOnTxFieldIndex = #fields + 1
+    fields[setNameOnTxFieldIndex] = { t = "Set name on TX",         x = x, y = incY(lineSpacing), sp = x + sp, data = { value = settings.autoSetName or 0, min = 0, max = 1, table = { [0] = "Off", "On" } } }
+    incY(lineSpacing * 0.25)
+    fields[#fields + 1] = { t = "Param1 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_type }
+    fields[#fields + 1] = { t = "Param1 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param1_value }
+    fields[#fields + 1] = { t = "Param2 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_type }
+    fields[#fields + 1] = { t = "Param2 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param2_value }
+    fields[#fields + 1] = { t = "Param3 type",  x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_type }
+    fields[#fields + 1] = { t = "Param3 value", x = x, y = incY(lineSpacing), sp = x + sp, data = pilotConfig.model_param3_value }
 
     page.labels = labels
     page.fields = fields
@@ -96,7 +120,7 @@ return {
     end,
     write = function(self)
         rf2.useApi("mspPilotConfig").write(pilotConfig)
-        settings.autoSetName = fields[1].data.value
+        settings.autoSetName = fields[setNameOnTxFieldIndex].data.value
         settingsHelper.saveSettings(settings)
         pilotConfigReset()
         rf2.settingsSaved(true, false)

--- a/src/SCRIPTS/RF2/PAGES/model.lua
+++ b/src/SCRIPTS/RF2/PAGES/model.lua
@@ -134,12 +134,16 @@ end
 return {
     read = function(self)
         rf2.useApi("mspName").getModelName(onReceivedModelName, self)
-        rf2.useApi("mspFlightStats").read(nil, nil, flighStats)
+        if rf2.apiVersion >= 12.09 then
+            rf2.useApi("mspFlightStats").read(nil, nil, flighStats)
+        end
         rf2.useApi("mspPilotConfig").read(onReceivedPilotConfig, self, pilotConfig)
     end,
     write = function(self)
         setAutoSetName()
-        rf2.useApi("mspFlightStats").write(flighStats)
+        if rf2.apiVersion >= 12.09 then
+            rf2.useApi("mspFlightStats").write(flighStats)
+        end
         rf2.useApi("mspPilotConfig").write(pilotConfig)
         pilotConfigReset()
         rf2.settingsSaved(true, false)

--- a/src/SCRIPTS/RF2/PAGES/settings.lua
+++ b/src/SCRIPTS/RF2/PAGES/settings.lua
@@ -1,5 +1,5 @@
 local template = rf2.executeScript(rf2.radio.template)
-local settingsHelper = rf2.executeScript("PAGES/helpers/settingsHelper")
+local settings = rf2.loadSettings()
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
@@ -11,7 +11,6 @@ local y = yMinLim - lineSpacing
 local function incY(val) y = y + val return y end
 local labels = {}
 local fields = {}
-local settings = settingsHelper.loadSettings()
 local hideShow = { [0] = "Hide", "Show" }
 local offOn = { [0] = "Off", "On" }
 
@@ -69,7 +68,7 @@ return {
         if rf2.canUseLvgl then
             settings.useLvgl = fields[9].data.value
         end
-        settingsHelper.saveSettings(settings)
+        rf2.saveSettings(settings)
         rf2.reloadMainMenu(true)
         rf2.settingsSaved(false, false)
     end,

--- a/src/SCRIPTS/RF2/PAGES/settings.lua
+++ b/src/SCRIPTS/RF2/PAGES/settings.lua
@@ -17,7 +17,7 @@ local offOn = { [0] = "Off", "On" }
 
 y = yMinLim - tableSpacing.header
 labels[1] = { t = "Display Various Pages",   x = x, y = incY(lineSpacing) }
-fields[1] = { t = "Model on TX",             x = x + indent, y = incY(lineSpacing), sp = x + sp }
+fields[1] = { t = "Model",                   x = x + indent, y = incY(lineSpacing), sp = x + sp }
 fields[2] = { t = "Experimental (!)",        x = x + indent, y = incY(lineSpacing), sp = x + sp }
 
 incY(lineSpacing * 0.5)

--- a/src/SCRIPTS/RF2/background_init.lua
+++ b/src/SCRIPTS/RF2/background_init.lua
@@ -1,10 +1,9 @@
 local initializationDone = false
 local crsfCustomTelemetryEnabled = false
 
-local settingsHelper = rf2.executeScript("PAGES/helpers/settingsHelper")
-local autoSetName = settingsHelper.loadSettings().autoSetName == 1 or false
-local useAdjustmentTeller = settingsHelper.loadSettings().useAdjustmentTeller == 1 or false
-settingsHelper = nil
+local settings = rf2.loadSettings()
+local autoSetName = settings.autoSetName == 1 or false
+local useAdjustmentTeller = settings.useAdjustmentTeller == 1 or false
 
 local pilotConfigSetMagic = -765
 local function pilotConfigSet()
@@ -55,7 +54,36 @@ local function setParam(paramType, paramValue)
     end
 end
 
+local function setModelName(name)
+    if not name then return end
+    --local newName = ">" .. ((name and #name > 0) and name or "Rotorflight")
+    local newName = name
+
+    local info = model.getInfo()
+    if info.name == newName then return end
+    settings.previousModelName = info.name
+    rf2.saveSettings(settings)
+    info.name = newName
+    model.setInfo(info)
+end
+
+local function resetModelName()
+    if not settings.previousModelName then return end
+    local info = model.getInfo()
+    info.name = settings.previousModelName
+    model.setInfo(info)
+    settings.previousModelName = nil
+    rf2.saveSettings(settings)
+end
+
 local function onPilotConfigReceived(_, config)
+    if rf2.apiVersion >= 12.09 then
+        -- RF 2.0 to 2.2 (MSP API 12.06 to 12.08) used settings.autoSetName (a global radio setting) to set the model name.
+        -- RF 2.3+ (MSP API 12.09+) uses a setting on the model to set the model name.
+        autoSetName = rf2.getBit(config.model_flags.value, config.model_flags.MODEL_SET_NAME) == 1 or false
+        --rf2.print("MODEL_SET_NAME: " .. tostring(autoSetName))
+    end
+
     local paramValue = config.model_param1_value.value
     local paramType = config.model_param1_type.table[config.model_param1_type.value]
     setParam(paramType, paramValue)
@@ -122,16 +150,6 @@ local function waitForCustomSensorsDiscovery()
     return 0
 end
 
-local function setModelName(name)
-    local newName = ">" .. ((name and #name > 0) and name or "Rotorflight")
-    local info = model.getInfo()
-    if info.name == newName then
-        return
-    end
-    info.name = newName
-    model.setInfo(info)
-end
-
 local queueInitialized = false
 local function initializeQueue()
     --rf2.print("Initializing MSP queue")
@@ -142,12 +160,7 @@ local function initializeQueue()
         function(_, version)
             rf2.apiVersion = version
 
-            if autoSetName then
-                rf2.useApi("mspName").getModelName(
-                    function(_, name)
-                        setModelName(name)
-                    end)
-            end
+            rf2.useApi("mspName").getModelName(function(_, name) rf2.modelName = name end)
 
             if rf2.apiVersion >= 12.07 then
                 if not pilotConfigHasBeenSet() then
@@ -164,6 +177,9 @@ local function initializeQueue()
 
             rf2.useApi("mspSetRtc").setRtc(
                 function()
+                    if autoSetName then
+                        setModelName(rf2.modelName)
+                    end
                     playTone(1600, 300, 0, PLAY_BACKGROUND)
                     --rf2.print("RTC set")
                     rf2.mspQueue.maxRetries = rf2.protocol.maxRetries
@@ -179,10 +195,7 @@ local function initialize(modelIsConnected)
     end
 
     if not modelIsConnected then
-        if autoSetName then
-            setModelName(nil)
-        end
-
+        resetModelName()
         return false
     end
 

--- a/src/SCRIPTS/RF2/pages.lua
+++ b/src/SCRIPTS/RF2/pages.lua
@@ -18,7 +18,7 @@ PageFiles[#PageFiles + 1] = { title = "Accelerometer Trim", script = "accelerome
 
 if rf2.apiVersion >= 12.07 then
     if settings.showModelOnTx == 1 then
-        PageFiles[#PageFiles + 1] = { title = "Model on TX", script = "model" }
+        PageFiles[#PageFiles + 1] = { title = "Model", script = "model" }
     end
     if settings.showExperimental == 1 then
         PageFiles[#PageFiles + 1] = { title = "Experimental (!)", script = "experimental" }

--- a/src/SCRIPTS/RF2/rf2.lua
+++ b/src/SCRIPTS/RF2/rf2.lua
@@ -34,6 +34,10 @@ rf2 = {
         return rf2.executeScript("PAGES/helpers/settingsHelper").loadSettings();
     end,
 
+    saveSettings = function(settings)
+        return rf2.executeScript("PAGES/helpers/settingsHelper").saveSettings(settings);
+    end,
+
     print = function(format, ...)
         local str = string.format("RF2: " .. format, ...)
         if rf2.runningInSimulator then

--- a/src/SCRIPTS/RF2/rf2.lua
+++ b/src/SCRIPTS/RF2/rf2.lua
@@ -82,6 +82,20 @@ rf2 = {
     -- Use LVGL graphics on color radios with EdgeTX 2.11 or higher
     canUseLvgl = lcd.setColor and (select(3, getVersion()) >= 3 or (select(3, getVersion()) == 2 and select(4, getVersion()) >= 11)),
 
+    getBit = function(value, number)
+        local mask = bit32.lshift(1, number)
+        return bit32.band(value, mask) ~= 0 and 1 or 0
+    end,
+
+    setBit = function(value, number, state)
+        local mask = bit32.lshift(1, number)
+        if state == 1 then
+            return bit32.bor(value, mask)
+        else
+            return bit32.band(value, bit32.bnot(mask))
+        end
+    end,
+
     --[[
     showMemoryUsage = function(remark)
         if not rf2.oldMemoryUsage then

--- a/src/SCRIPTS/RF2/rf2.lua
+++ b/src/SCRIPTS/RF2/rf2.lua
@@ -72,7 +72,8 @@ rf2 = {
         milliseconds = " ms",
         volt = "V",
         celsius = " C",
-        rpm = " RPM"
+        rpm = " RPM",
+        meters = " m"
     },
 
     -- Color radios on EdgeTX >= 2.11 do not send EVT_VIRTUAL_ENTER anymore after EVT_VIRTUAL_ENTER_LONG

--- a/src/SCRIPTS/RF2/ui_lcd.lua
+++ b/src/SCRIPTS/RF2/ui_lcd.lua
@@ -234,18 +234,23 @@ local function fieldIsButton(f)
 end
 
 local function drawScreen()
-    if currentField > #Page.fields then currentField = #Page.fields end
     local yMinLim = rf2.radio.yMinLimit
     local yMaxLim = rf2.radio.yMaxLimit
-    local currentFieldY = Page.fields[currentField].y
     local textOptions = rf2.radio.textSize + globalTextOptions
     local boldTextOptions = (rf2.isEdgeTx and TEXT_COLOR and BOLD + TEXT_COLOR) or textOptions
-    if currentFieldY <= Page.fields[1].y then
+
+    if #Page.fields == 0 then
         pageScrollY = 0
-    elseif currentFieldY - pageScrollY <= yMinLim then
-        pageScrollY = currentFieldY - yMinLim
-    elseif currentFieldY - pageScrollY >= yMaxLim then
-        pageScrollY = currentFieldY - yMaxLim
+    else
+        if currentField > #Page.fields then currentField = #Page.fields end
+        local currentFieldY = Page.fields[currentField] and Page.fields[currentField].y or 0
+        if currentFieldY <= Page.fields[1].y then
+            pageScrollY = 0
+        elseif currentFieldY - pageScrollY <= yMinLim then
+            pageScrollY = currentFieldY - yMinLim
+        elseif currentFieldY - pageScrollY >= yMaxLim then
+            pageScrollY = currentFieldY - yMaxLim
+        end
     end
     for i=1,#Page.labels do
         local f = Page.labels[i]


### PR DESCRIPTION
The flight statistics were only accessible through CLI. This PR adds support for Lua by extending the Model page with those statistics:
![image](https://github.com/user-attachments/assets/ed368fa9-4ed2-48fc-8d79-7651344f0e9a)
The PR also adds support for setting the model name per model, instead of setting the model name for *all* models that use rf2bg.

Depends on https://github.com/rotorflight/rotorflight-firmware/pull/317