### PR TITLE
HW5 Table Support

### DIFF
--- a/src/SCRIPTS/RF2/LCD/page.lua
+++ b/src/SCRIPTS/RF2/LCD/page.lua
@@ -54,7 +54,7 @@ t.draw = function(pageState)
                     val = math.floor(val)
                 end
             end
-            if f.data.table and f.data.table[val] then
+            if type(f.data.table) == "table" and f.data.table[val] then
                 val = f.data.table[val]
             end
         end

--- a/src/SCRIPTS/RF2/LCD/page.lua
+++ b/src/SCRIPTS/RF2/LCD/page.lua
@@ -44,7 +44,7 @@ t.draw = function(pageState)
                 valueOptions = valueOptions + BLINK
             end
         end
-        if f.data and f.data.value then
+        if f.data and f.data.value ~= nil then
             val = f.data.value
             if type(val) == "number" then
                 if f.data.scale then

--- a/src/SCRIPTS/RF2/LVGL/page.lua
+++ b/src/SCRIPTS/RF2/LVGL/page.lua
@@ -61,7 +61,7 @@ local function show(page)
                     if field.preEdit then field.preEdit(field, page) end
                 end,
             }
-        elseif field.data and field.data.value and type(field.data.value) == "string" then
+        elseif field.data and field.data.value ~= nil and type(field.data.value) == "string" then
             local child
             if field.readOnly then
                 child = {
@@ -82,7 +82,7 @@ local function show(page)
             end
 
             children[#children + 1] = child
-        elseif field.data and field.data.value and type(field.data.value) == "number" then
+        elseif field.data and field.data.value ~= nil and type(field.data.value) == "number" then
             local child
             if field.readOnly then
                 child = {
@@ -93,7 +93,7 @@ local function show(page)
                         return formatVal(field.data.value, field)
                     end,
                 }
-            elseif field.data.table then
+            elseif type(field.data.table) == "table" then
                 local choiceTable = lvglHelper.toChoiceTable(field.data.table, field.data.max + 1)
                 --rf2.print("Choice with value: " .. tostring(field.data.value))
                 child = {

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -15,6 +15,11 @@ local lipoCellCount2To4 = {
     "2S", "3S", "4S",
 }
 
+local lipoCellCountEven6To14 = {
+    [0] = "Auto",
+    "6S", "8S", "10S", "12S", "14S",
+}
+
 local cutoffType = {
     [0] = "Soft",
     "Hard"
@@ -181,16 +186,16 @@ local PROFILES = {
         lipo = lipoCellCount,
         cutoffVoltage = cutoffVoltage,
     },
-    ["HW1104_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1104_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
     ["HW1106_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 54, max = 84, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    ["HW1106_V200456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V200456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    ["HW198_V1.00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    HW1128 = { layout = HW1128_LAYOUT, bec = nil, brake = brakeTypeBasic, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage25To38 },
-    OPTO = { layout = OPTO_LAYOUT, bec = nil, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW198_V1.00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
+    HW1128 = { layout = HW1128_LAYOUT, bec = nil, brake = brakeTypeNoProportional, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage25To38 },
+    OPTO = { layout = OPTO_LAYOUT, bec = nil, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
 }
 
 local function trim(value)

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -43,6 +43,14 @@ local restartTime = {
     "3 s",
 }
 
+local responseTime = {
+    [0] = "1",
+    "2",
+    "3",
+    "4",
+    "5",
+}
+
 local rotation = {
     [0] = "CW",
     "CCW",
@@ -96,6 +104,7 @@ local VALUE_FIELDS = {
     "cutoff_voltage",
     "bec_voltage",
     "startup_time",
+    "response_time",
     "gov_p_gain",
     "gov_i_gain",
     "auto_restart",
@@ -128,22 +137,15 @@ local DEFAULT_LAYOUT = {
 }
 
 local HW1132_LAYOUT = {
-    flight_mode = 1,
-    lipo_cell_count = 2,
+    lipo_cell_count = 1,
+    cutoff_type = 2,
     cutoff_voltage = 3,
     bec_voltage = 4,
-    cutoff_type = 5,
-    startup_time = 6,
-    gov_p_gain = 7,
-    gov_i_gain = 8,
-    auto_restart = 9,
-    restart_time = 10,
-    brake_type = 11,
-    brake_force = 12,
-    timing = 13,
-    rotation = 14,
-    active_freewheel = 15,
-    startup_power = 16,
+    response_time = 5,
+    timing = 6,
+    rotation = 7,
+    active_freewheel = 8,
+    startup_power = 9,
 }
 
 local HW1128_LAYOUT = {
@@ -192,7 +194,7 @@ local PROFILES = {
     ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage, response = responseTime },
     ["HW198_V1.00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
     HW1128 = { layout = HW1128_LAYOUT, bec = nil, brake = brakeTypeNoProportional, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage25To38 },
     OPTO = { layout = OPTO_LAYOUT, bec = nil, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
@@ -244,6 +246,7 @@ local function applyProfile(data, profile)
     applyTable(data.cutoff_type, cutoffType)
     applyTable(data.cutoff_voltage, profile.cutoffVoltage or cutoffVoltage)
     applyTable(data.restart_time, restartTime)
+    applyTable(data.response_time, profile.response or responseTime)
     applyTable(data.brake_type, profile.brake or brakeType)
     applyTable(data.rotation, rotation)
     applyTable(data.active_freewheel, enabledDisabled)
@@ -313,6 +316,7 @@ local function getDefaults()
         cutoff_voltage = { min = 0, max = #cutoffVoltage, table = cutoffVoltage },
         bec_voltage = { min = 50, max = 84, scale = 10, unit = rf2.units.volt },
         startup_time = { min = 4, max = 25, unit = rf2.units.seconds },
+        response_time = { min = 0, max = #responseTime, table = responseTime },
         gov_p_gain = { min = 0, max = 9 },
         gov_i_gain = { min = 0, max = 9 },
         auto_restart = { min = 0, max = 90, unit = rf2.units.seconds },

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -10,6 +10,11 @@ local lipoCellCount = {
     "3S", "4S", "5S", "6S", "7S", "8S", "9S", "10S", "11S", "12S", "13S", "14S",
 }
 
+local lipoCellCount2To4 = {
+    [0] = "Auto",
+    "2S", "3S", "4S",
+}
+
 local cutoffType = {
     [0] = "Soft",
     "Hard"
@@ -18,6 +23,11 @@ local cutoffType = {
 local cutoffVoltage = {
     [0] = "Disabled",
     "2.8V", "2.9V", "3.0V", "3.1V", "3.2V", "3.3V", "3.4V", "3.5V", "3.6V", "3.7V", "3.8V",
+}
+
+local cutoffVoltage25To38 = {
+    [0] = "Disabled",
+    "2.5V", "2.6V", "2.7V", "2.8V", "2.9V", "3.0V", "3.1V", "3.2V", "3.3V", "3.4V", "3.5V", "3.6V", "3.7V", "3.8V",
 }
 
 local restartTime = {
@@ -40,6 +50,17 @@ local brakeType = {
     "Reverse"
 }
 
+local brakeTypeNoProportional = {
+    [0] = "Disabled",
+    "Normal",
+    "Reverse"
+}
+
+local brakeTypeBasic = {
+    [0] = "Disabled",
+    "Normal",
+}
+
 local enabledDisabled = {
     [0] = "Enabled",
     "Disabled",
@@ -55,20 +76,222 @@ local startupPower = {
     "Level 7",
 }
 
--- Voltage lookup table based on hardware version
--- Each hardware version maps to a list of possible BEC voltage settings
--- The values are representing voltage in volts * 10
--- Values are min, max, scale
--- Example: 8.4V == 84, scale factor is 10 == 0.1V steps
-local voltagesLookup = {
-    ["HW1104_V100456NB"] = {50, 120, 10},
-    ["HW1106_V100456NB"] = {54, 84, 10},
-    ["HW1106_V200456NB"] = {50, 120, 10},
-    ["HW1106_V300456NB"] = {50, 120, 10},
-    ["HW1121_V100456NB"] = {50, 120, 10},
-    ["HW198_V1.00456NB"] = {50, 120, 10},
-    ["default"] = {50, 84, 10},
+local becVoltage60To84 = {
+    [0] = "6.0V",
+    "7.4V",
+    "8.4V",
 }
+
+local ITEM_COUNT = 16
+
+local VALUE_FIELDS = {
+    "flight_mode",
+    "lipo_cell_count",
+    "cutoff_type",
+    "cutoff_voltage",
+    "bec_voltage",
+    "startup_time",
+    "gov_p_gain",
+    "gov_i_gain",
+    "auto_restart",
+    "restart_time",
+    "brake_type",
+    "brake_force",
+    "timing",
+    "rotation",
+    "active_freewheel",
+    "startup_power",
+}
+
+local DEFAULT_LAYOUT = {
+    flight_mode = 1,
+    lipo_cell_count = 2,
+    cutoff_type = 3,
+    cutoff_voltage = 4,
+    bec_voltage = 5,
+    startup_time = 6,
+    gov_p_gain = 7,
+    gov_i_gain = 8,
+    auto_restart = 9,
+    restart_time = 10,
+    brake_type = 11,
+    brake_force = 12,
+    timing = 13,
+    rotation = 14,
+    active_freewheel = 15,
+    startup_power = 16,
+}
+
+local HW1132_LAYOUT = {
+    flight_mode = 1,
+    lipo_cell_count = 2,
+    cutoff_voltage = 3,
+    bec_voltage = 4,
+    cutoff_type = 5,
+    startup_time = 6,
+    gov_p_gain = 7,
+    gov_i_gain = 8,
+    auto_restart = 9,
+    restart_time = 10,
+    brake_type = 11,
+    brake_force = 12,
+    timing = 13,
+    rotation = 14,
+    active_freewheel = 15,
+    startup_power = 16,
+}
+
+local HW1128_LAYOUT = {
+    lipo_cell_count = 1,
+    cutoff_type = 2,
+    cutoff_voltage = 3,
+    brake_type = 5,
+    brake_force = 6,
+    timing = 7,
+    rotation = 8,
+    active_freewheel = 9,
+    startup_power = 10,
+}
+
+local OPTO_LAYOUT = {
+    flight_mode = 1,
+    lipo_cell_count = 2,
+    cutoff_type = 3,
+    cutoff_voltage = 4,
+    startup_time = 5,
+    gov_p_gain = 6,
+    gov_i_gain = 7,
+    auto_restart = 8,
+    restart_time = 9,
+    brake_type = 10,
+    brake_force = 11,
+    timing = 12,
+    rotation = 13,
+    active_freewheel = 14,
+    startup_power = 15,
+}
+
+local DEFAULT_BEC = { min = 50, max = 84, scale = 10 }
+
+local PROFILES = {
+    default = {
+        layout = DEFAULT_LAYOUT,
+        bec = DEFAULT_BEC,
+        brake = brakeType,
+        lipo = lipoCellCount,
+        cutoffVoltage = cutoffVoltage,
+    },
+    ["HW1104_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 54, max = 84, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V200456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1121_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1121_V00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW198_V1.00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    HW1128 = { layout = HW1128_LAYOUT, bec = nil, brake = brakeTypeBasic, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage25To38 },
+    OPTO = { layout = OPTO_LAYOUT, bec = nil, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+}
+
+local function trim(value)
+    if not value then return "" end
+    return tostring(value):gsub("%z.*", ""):match("^%s*(.-)%s*$")
+end
+
+local function startsWith(value, prefix)
+    return string.sub(value or "", 1, #prefix) == prefix
+end
+
+local function selectProfile(hardwareVersion, escType, firmwareVersion)
+    local hardware = trim(hardwareVersion)
+    local esc = trim(escType)
+    local firmware = trim(firmwareVersion)
+
+    if string.find(esc, "OPTO", 1, true) or string.find(firmware, "OPTO", 1, true) then
+        return PROFILES.OPTO
+    end
+
+    if PROFILES[hardware] then
+        return PROFILES[hardware]
+    end
+
+    if startsWith(hardware, "HW1132_") then
+        return PROFILES["HW1132_V100456NB"]
+    elseif startsWith(hardware, "HW1128_") then
+        return PROFILES.HW1128
+    elseif startsWith(hardware, "HW1121_") then
+        return PROFILES["HW1121_V100456NB"]
+    end
+
+    return PROFILES.default
+end
+
+local function applyTable(field, tableDef)
+    field.table = tableDef
+    field.min = 0
+    field.max = #tableDef
+end
+
+local function applyProfile(data, profile)
+    applyTable(data.flight_mode, flightMode)
+    applyTable(data.lipo_cell_count, profile.lipo or lipoCellCount)
+    applyTable(data.cutoff_type, cutoffType)
+    applyTable(data.cutoff_voltage, profile.cutoffVoltage or cutoffVoltage)
+    applyTable(data.restart_time, restartTime)
+    applyTable(data.brake_type, profile.brake or brakeType)
+    applyTable(data.rotation, rotation)
+    applyTable(data.active_freewheel, enabledDisabled)
+    applyTable(data.startup_power, startupPower)
+
+    if profile.bec and profile.bec.table then
+        applyTable(data.bec_voltage, profile.bec.table)
+        data.bec_voltage.scale = nil
+        data.bec_voltage.unit = nil
+    elseif profile.bec then
+        data.bec_voltage.table = nil
+        data.bec_voltage.min = profile.bec.min
+        data.bec_voltage.max = profile.bec.max
+        data.bec_voltage.scale = profile.bec.scale
+        data.bec_voltage.unit = rf2.units.volt
+    else
+        data.bec_voltage.table = nil
+        data.bec_voltage.value = nil
+        data.bec_voltage.scale = nil
+        data.bec_voltage.unit = nil
+    end
+
+    data._profile = profile
+    data._layout = profile.layout
+    data._supported = {}
+    for _, fieldName in ipairs(VALUE_FIELDS) do
+        data._supported[fieldName] = profile.layout[fieldName] ~= nil
+    end
+end
+
+local function setFieldValue(data, profile, fieldName, rawValue)
+    local field = data[fieldName]
+    if rawValue == nil then
+        field.value = nil
+    elseif fieldName == "bec_voltage" and profile.bec and not profile.bec.table then
+        field.value = rawValue + profile.bec.min
+    elseif fieldName == "startup_time" then
+        field.value = rawValue + 4
+    else
+        field.value = rawValue
+    end
+end
+
+local function getFieldRawValue(data, profile, fieldName)
+    local field = data[fieldName]
+    local value = field and field.value
+    if value == nil then return nil end
+    if fieldName == "bec_voltage" and profile.bec and not profile.bec.table then
+        return value - profile.bec.min
+    elseif fieldName == "startup_time" then
+        return value - 4
+    end
+    return value
+end
 
 local function getDefaults()
     return {
@@ -82,7 +305,7 @@ local function getDefaults()
         lipo_cell_count = { min = 0, max = #lipoCellCount, table = lipoCellCount },
         cutoff_type = { min = 0, max = #cutoffType, table = cutoffType },
         cutoff_voltage = { min = 0, max = #cutoffVoltage, table = cutoffVoltage },
-        bec_voltage = { min = 54, max = 84, scale = 10, unit = rf2.units.volt },
+        bec_voltage = { min = 50, max = 84, scale = 10, unit = rf2.units.volt },
         startup_time = { min = 4, max = 25, unit = rf2.units.seconds },
         gov_p_gain = { min = 0, max = 9 },
         gov_i_gain = { min = 0, max = 9 },
@@ -94,6 +317,9 @@ local function getDefaults()
         rotation = { min = 0, max = #rotation, table = rotation },
         active_freewheel = { min = 0, max = #enabledDisabled, table = enabledDisabled },
         startup_power = { min = 0, max = #startupPower, table = startupPower },
+        _itemBytes = {},
+        _layout = DEFAULT_LAYOUT,
+        _supported = {},
     }
 end
 
@@ -105,7 +331,6 @@ local function getEscParameters(callback, callbackParam, data)
         processReply = function(self, buf)
             data.esc_signature.value = rf2.mspHelper.readU8(buf)
             if data.esc_signature.value ~= 253 then
-                --rf2.print("warning: Invalid ESC signature: " .. tostring(data.esc_signature))
                 return
             end
             data.command.value = rf2.mspHelper.readU8(buf)
@@ -113,27 +338,20 @@ local function getEscParameters(callback, callbackParam, data)
             data.hardware_version.value = rf2.mspHelper.readText(buf, 16)
             data.esc_type2.value = rf2.mspHelper.readText(buf, 16)
             data.esc_type.value = rf2.mspHelper.readText(buf, 15)
-            data.flight_mode.value = rf2.mspHelper.readU8(buf)
-            data.lipo_cell_count.value = rf2.mspHelper.readU8(buf)
-            data.cutoff_type.value = rf2.mspHelper.readU8(buf)
-            data.cutoff_voltage.value = rf2.mspHelper.readU8(buf)
-            data.bec_voltage.value = rf2.mspHelper.readU8(buf) + 54
-            --  get voltage range based on hardware version
-            local voltages = voltagesLookup[data.hardware_version.value] or voltagesLookup["default"]
-            data.bec_voltage.min = voltages[1]
-            data.bec_voltage.max = voltages[2]
-            data.bec_voltage.scale = voltages[3]
-            data.startup_time.value = rf2.mspHelper.readU8(buf) + 4
-            data.gov_p_gain.value = rf2.mspHelper.readU8(buf)
-            data.gov_i_gain.value = rf2.mspHelper.readU8(buf)
-            data.auto_restart.value = rf2.mspHelper.readU8(buf)
-            data.restart_time.value = rf2.mspHelper.readU8(buf)
-            data.brake_type.value = rf2.mspHelper.readU8(buf)
-            data.brake_force.value = rf2.mspHelper.readU8(buf)
-            data.timing.value = rf2.mspHelper.readU8(buf)
-            data.rotation.value = rf2.mspHelper.readU8(buf)
-            data.active_freewheel.value = rf2.mspHelper.readU8(buf)
-            data.startup_power.value = rf2.mspHelper.readU8(buf)
+
+            local itemBytes = {}
+            for i = 1, ITEM_COUNT do
+                itemBytes[i] = rf2.mspHelper.readU8(buf)
+            end
+
+            local profile = selectProfile(data.hardware_version.value, (data.esc_type2.value or "") .. (data.esc_type.value or ""), data.firmware_version.value)
+            applyProfile(data, profile)
+            data._itemBytes = itemBytes
+
+            for _, fieldName in ipairs(VALUE_FIELDS) do
+                setFieldValue(data, profile, fieldName, itemBytes[profile.layout[fieldName]])
+            end
+
             callback(callbackParam, data)
         end,
         simulatorResponse = { 253, 0, 32, 32, 32, 80, 76, 45, 48, 52, 46, 49, 46, 48, 50, 32, 32, 32, 72, 87, 49, 49, 48, 54, 95, 86, 49, 48, 48, 52, 53, 54, 78, 66, 80, 108, 97, 116, 105, 110, 117, 109, 95, 86, 53, 32, 32, 32, 32, 32, 80, 108, 97, 116, 105, 110, 117, 109, 32, 86, 53, 32, 32, 32, 32, 0, 0, 0, 3, 0, 11, 6, 5, 25, 1, 0, 0, 24, 0, 0, 2 },
@@ -142,32 +360,34 @@ local function getEscParameters(callback, callbackParam, data)
 end
 
 local function setEscParameters(data)
+    local profile = data._profile or selectProfile(data.hardware_version.value, (data.esc_type2.value or "") .. (data.esc_type.value or ""), data.firmware_version.value)
+    local itemBytes = {}
+
+    for i = 1, ITEM_COUNT do
+        itemBytes[i] = (data._itemBytes and data._itemBytes[i]) or 0
+    end
+
+    for _, fieldName in ipairs(VALUE_FIELDS) do
+        local itemIndex = profile.layout[fieldName]
+        local rawValue = getFieldRawValue(data, profile, fieldName)
+        if itemIndex and rawValue ~= nil then
+            itemBytes[itemIndex] = rawValue
+        end
+    end
+
     local message = {
         command = 218, -- MSP_SET_ESC_PARAMETERS
         payload = {}
     }
     rf2.mspHelper.writeU8(message.payload, data.esc_signature.value)
     rf2.mspHelper.writeU8(message.payload, data.command.value)
-    rf2.mspHelper.writeText(message.payload, data.firmware_version.value, 16)
-    rf2.mspHelper.writeText(message.payload, data.hardware_version.value, 16)
-    rf2.mspHelper.writeText(message.payload, data.esc_type2.value, 16)
-    rf2.mspHelper.writeText(message.payload, data.esc_type.value, 15)
-    rf2.mspHelper.writeU8(message.payload, data.flight_mode.value)
-    rf2.mspHelper.writeU8(message.payload, data.lipo_cell_count.value)
-    rf2.mspHelper.writeU8(message.payload, data.cutoff_type.value)
-    rf2.mspHelper.writeU8(message.payload, data.cutoff_voltage.value)
-    rf2.mspHelper.writeU8(message.payload, data.bec_voltage.value - 54)
-    rf2.mspHelper.writeU8(message.payload, data.startup_time.value - 4)
-    rf2.mspHelper.writeU8(message.payload, data.gov_p_gain.value)
-    rf2.mspHelper.writeU8(message.payload, data.gov_i_gain.value)
-    rf2.mspHelper.writeU8(message.payload, data.auto_restart.value)
-    rf2.mspHelper.writeU8(message.payload, data.restart_time.value)
-    rf2.mspHelper.writeU8(message.payload, data.brake_type.value)
-    rf2.mspHelper.writeU8(message.payload, data.brake_force.value)
-    rf2.mspHelper.writeU8(message.payload, data.timing.value)
-    rf2.mspHelper.writeU8(message.payload, data.rotation.value)
-    rf2.mspHelper.writeU8(message.payload, data.active_freewheel.value)
-    rf2.mspHelper.writeU8(message.payload, data.startup_power.value)
+    rf2.mspHelper.writeText(message.payload, data.firmware_version.value or "", 16)
+    rf2.mspHelper.writeText(message.payload, data.hardware_version.value or "", 16)
+    rf2.mspHelper.writeText(message.payload, data.esc_type2.value or "", 16)
+    rf2.mspHelper.writeText(message.payload, data.esc_type.value or "", 15)
+    for i = 1, ITEM_COUNT do
+        rf2.mspHelper.writeU8(message.payload, itemBytes[i] or 0)
+    end
     rf2.mspQueue:add(message)
 end
 
@@ -176,4 +396,3 @@ return {
     write = setEscParameters,
     getDefaults = getDefaults
 }
-

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -15,6 +15,11 @@ local lipoCellCount2To4 = {
     "2S", "3S", "4S",
 }
 
+local lipoCellCount3To8 = {
+    [0] = "Auto",
+    "3S", "4S", "5S", "6S", "7S", "8S",
+}
+
 local lipoCellCountEven6To14 = {
     [0] = "Auto",
     "6S", "8S", "10S", "12S", "14S",
@@ -189,7 +194,7 @@ local PROFILES = {
         cutoffVoltage = cutoffVoltage,
     },
     ["HW1104_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
-    ["HW1106_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 54, max = 84, scale = 10 }, brake = brakeType, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
+    ["HW1106_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 54, max = 84, scale = 10 }, brake = brakeType, lipo = lipoCellCount3To8, cutoffVoltage = cutoffVoltage },
     ["HW1106_V200456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -54,6 +54,11 @@ local responseTime = {
     "3",
     "4",
     "5",
+    "6",
+    "7",
+    "8",
+    "9",
+    "10",
 }
 
 local rotation = {
@@ -199,7 +204,7 @@ local PROFILES = {
     ["HW1106_V300456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V100456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
     ["HW1121_V00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage },
-    ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount, cutoffVoltage = cutoffVoltage, response = responseTime },
+    ["HW1132_V100456NB"] = { layout = HW1132_LAYOUT, bec = { table = becVoltage60To84 }, brake = brakeTypeNoProportional, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage, response = responseTime },
     ["HW198_V1.00456NB"] = { layout = DEFAULT_LAYOUT, bec = { min = 50, max = 120, scale = 10 }, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },
     HW1128 = { layout = HW1128_LAYOUT, bec = nil, brake = brakeTypeNoProportional, lipo = lipoCellCount2To4, cutoffVoltage = cutoffVoltage25To38 },
     OPTO = { layout = OPTO_LAYOUT, bec = nil, brake = brakeTypeBasic, lipo = lipoCellCountEven6To14, cutoffVoltage = cutoffVoltage },

--- a/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
+++ b/src/SCRIPTS/RF2/MSP/mspEscHwPl5.lua
@@ -195,7 +195,8 @@ local PROFILES = {
 
 local function trim(value)
     if not value then return "" end
-    return tostring(value):gsub("%z.*", ""):match("^%s*(.-)%s*$")
+    local text = string.gsub(tostring(value), "%z.*", "")
+    return string.match(text, "^%s*(.-)%s*$")
 end
 
 local function startsWith(value, prefix)

--- a/src/SCRIPTS/RF2/PAGES/esc_hwpl5.lua
+++ b/src/SCRIPTS/RF2/PAGES/esc_hwpl5.lua
@@ -17,30 +17,30 @@ labels[1] = { t = "ESC not ready, waiting...", x = x,   y = incY(lineSpacing) }
 labels[2] = { t = "---",                x = x + indent, y = incY(lineSpacing), bold = false }
 labels[3] = { t = "---",                x = x + indent, y = incY(lineSpacing), bold = false }
 
-fields[1] = { t = "Flight Mode",        x = x,          y = incY(lineSpacing * 2), sp = x + sp, w = 125, data = escParameters.flight_mode }
-fields[2] = { t = "Rotation",           x = x,          y = incY(lineSpacing), sp = x + sp,     data = escParameters.rotation }
+fields[1] = { t = "Flight Mode",        x = x,          y = incY(lineSpacing * 2), sp = x + sp, w = 125, data = escParameters.flight_mode, dataKey = "flight_mode" }
+fields[2] = { t = "Rotation",           x = x,          y = incY(lineSpacing), sp = x + sp,     data = escParameters.rotation, dataKey = "rotation" }
 
 labels[4] = { t = "Voltage",            x = x,          y = incY(lineSpacing * 2) }
-fields[3] = { t = "BEC Voltage",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.bec_voltage }
-fields[4] = { t = "Lipo Cell Count",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.lipo_cell_count }
-fields[5] = { t = "Volt Cutoff Type",   x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_type }
-fields[6] = { t = "Cuttoff Voltage",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_voltage }
+fields[3] = { t = "BEC Voltage",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.bec_voltage, dataKey = "bec_voltage" }
+fields[4] = { t = "Lipo Cell Count",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.lipo_cell_count, dataKey = "lipo_cell_count" }
+fields[5] = { t = "Volt Cutoff Type",   x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_type, dataKey = "cutoff_type" }
+fields[6] = { t = "Cuttoff Voltage",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_voltage, dataKey = "cutoff_voltage" }
 
 labels[5] = { t = "Governor",           x = x,          y = incY(lineSpacing) }
-fields[7] = { t = "P-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_p_gain }
-fields[8] = { t = "I-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_i_gain }
+fields[7] = { t = "P-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_p_gain, dataKey = "gov_p_gain" }
+fields[8] = { t = "I-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_i_gain, dataKey = "gov_i_gain" }
 
 labels[6] = { t = "Soft Start",         x = x,          y = incY(lineSpacing) }
-fields[9] = { t = "Startup Time",       x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_time }
-fields[10] = { t = "Restart Time",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.restart_time }
-fields[11] = { t = "Auto Restart",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.auto_restart }
+fields[9] = { t = "Startup Time",       x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_time, dataKey = "startup_time" }
+fields[10] = { t = "Restart Time",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.restart_time, dataKey = "restart_time" }
+fields[11] = { t = "Auto Restart",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.auto_restart, dataKey = "auto_restart" }
 
 labels[7] = { t = "Motor",              x = x,          y = incY(lineSpacing) }
-fields[12] = { t = "Timing",            x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.timing }
-fields[13] = { t = "Startup Power",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_power }
-fields[14] = { t = "Active Freewheel",  x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.active_freewheel }
-fields[15] = { t = "Brake Type",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_type }
-fields[16] = { t = "Brake Force %",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_force }
+fields[12] = { t = "Timing",            x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.timing, dataKey = "timing" }
+fields[13] = { t = "Startup Power",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_power, dataKey = "startup_power" }
+fields[14] = { t = "Active Freewheel",  x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.active_freewheel, dataKey = "active_freewheel" }
+fields[15] = { t = "Brake Type",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_type, dataKey = "brake_type" }
+fields[16] = { t = "Brake Force %",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_force, dataKey = "brake_force" }
 
 local function receivedEscParameters(page, data)
     if data.esc_signature.value ~= 253 then -- Hobbywing Platinum V5 signature
@@ -49,6 +49,13 @@ local function receivedEscParameters(page, data)
         page.labels[1].t = data.esc_type.value
         page.labels[2].t = "HW: " .. data.hardware_version.value
         page.labels[3].t = "FW:" .. data.firmware_version.value
+    end
+
+    if data._supported then
+        for i = 1, #page.fields do
+            local field = page.fields[i]
+            field.readOnly = field.dataKey and not data._supported[field.dataKey]
+        end
     end
 
     page.readOnly = false     -- enable 'Save Page'

--- a/src/SCRIPTS/RF2/PAGES/esc_hwpl5.lua
+++ b/src/SCRIPTS/RF2/PAGES/esc_hwpl5.lua
@@ -2,60 +2,132 @@ local template = rf2.executeScript(rf2.radio.template)
 local margin = template.margin
 local indent = template.indent
 local lineSpacing = template.lineSpacing
-local tableSpacing = template.tableSpacing
 local sp = template.listSpacing.field
 local yMinLim = rf2.radio.yMinLimit
 local x = margin
-local y = yMinLim - lineSpacing
-local function incY(val) y = y + val return y end
-local labels = {}
-local fields = {}
 local mspEscHwPl5 = "mspEscHwPl5"
 local escParameters = rf2.useApi(mspEscHwPl5).getDefaults()
 
-labels[1] = { t = "ESC not ready, waiting...", x = x,   y = incY(lineSpacing) }
-labels[2] = { t = "---",                x = x + indent, y = incY(lineSpacing), bold = false }
-labels[3] = { t = "---",                x = x + indent, y = incY(lineSpacing), bold = false }
+local sections = {
+    {
+        gap = lineSpacing * 2,
+        fields = {
+            { t = "Flight Mode", dataKey = "flight_mode", indent = false, w = 125 },
+            { t = "Rotation", dataKey = "rotation", indent = false },
+        }
+    },
+    {
+        title = "Voltage",
+        gap = lineSpacing * 2,
+        fields = {
+            { t = "BEC Voltage", dataKey = "bec_voltage" },
+            { t = "Lipo Cell Count", dataKey = "lipo_cell_count" },
+            { t = "Volt Cutoff Type", dataKey = "cutoff_type" },
+            { t = "Cuttoff Voltage", dataKey = "cutoff_voltage" },
+        }
+    },
+    {
+        title = "Governor",
+        fields = {
+            { t = "P-Gain", dataKey = "gov_p_gain" },
+            { t = "I-Gain", dataKey = "gov_i_gain" },
+        }
+    },
+    {
+        title = "Soft Start",
+        fields = {
+            { t = "Startup Time", dataKey = "startup_time" },
+            { t = "Restart Time", dataKey = "restart_time" },
+            { t = "Auto Restart", dataKey = "auto_restart" },
+        }
+    },
+    {
+        title = "Motor",
+        fields = {
+            { t = "Timing", dataKey = "timing" },
+            { t = "Startup Power", dataKey = "startup_power" },
+            { t = "Active Freewheel", dataKey = "active_freewheel" },
+            { t = "Response Time", dataKey = "response_time" },
+        }
+    },
+    {
+        title = "Brake",
+        fields = {
+            { t = "Brake Type", dataKey = "brake_type" },
+            { t = "Brake Force %", dataKey = "brake_force" },
+        }
+    },
+}
 
-fields[1] = { t = "Flight Mode",        x = x,          y = incY(lineSpacing * 2), sp = x + sp, w = 125, data = escParameters.flight_mode, dataKey = "flight_mode" }
-fields[2] = { t = "Rotation",           x = x,          y = incY(lineSpacing), sp = x + sp,     data = escParameters.rotation, dataKey = "rotation" }
+local function buildForm(data)
+    data = data or escParameters
+    local y = yMinLim - lineSpacing
+    local function incY(val) y = y + val return y end
+    local labels = {}
+    local fields = {}
+    local supported = data._supported
+    local filter = type(supported) == "table" and next(supported) ~= nil
 
-labels[4] = { t = "Voltage",            x = x,          y = incY(lineSpacing * 2) }
-fields[3] = { t = "BEC Voltage",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.bec_voltage, dataKey = "bec_voltage" }
-fields[4] = { t = "Lipo Cell Count",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.lipo_cell_count, dataKey = "lipo_cell_count" }
-fields[5] = { t = "Volt Cutoff Type",   x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_type, dataKey = "cutoff_type" }
-fields[6] = { t = "Cuttoff Voltage",    x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.cutoff_voltage, dataKey = "cutoff_voltage" }
+    local function isSupported(dataKey)
+        return not filter or supported[dataKey] == true
+    end
 
-labels[5] = { t = "Governor",           x = x,          y = incY(lineSpacing) }
-fields[7] = { t = "P-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_p_gain, dataKey = "gov_p_gain" }
-fields[8] = { t = "I-Gain",             x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.gov_i_gain, dataKey = "gov_i_gain" }
+    local function sectionHasFields(section)
+        for i = 1, #section.fields do
+            if isSupported(section.fields[i].dataKey) then return true end
+        end
+        return false
+    end
 
-labels[6] = { t = "Soft Start",         x = x,          y = incY(lineSpacing) }
-fields[9] = { t = "Startup Time",       x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_time, dataKey = "startup_time" }
-fields[10] = { t = "Restart Time",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.restart_time, dataKey = "restart_time" }
-fields[11] = { t = "Auto Restart",      x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.auto_restart, dataKey = "auto_restart" }
+    local function addField(def)
+        if not isSupported(def.dataKey) then return end
+        local field = {
+            t = def.t,
+            x = x + (def.indent == false and 0 or indent),
+            y = incY(lineSpacing),
+            sp = x + sp,
+            data = data[def.dataKey],
+            dataKey = def.dataKey
+        }
+        if def.w then field.w = def.w end
+        fields[#fields + 1] = field
+    end
 
-labels[7] = { t = "Motor",              x = x,          y = incY(lineSpacing) }
-fields[12] = { t = "Timing",            x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.timing, dataKey = "timing" }
-fields[13] = { t = "Startup Power",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.startup_power, dataKey = "startup_power" }
-fields[14] = { t = "Active Freewheel",  x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.active_freewheel, dataKey = "active_freewheel" }
-fields[15] = { t = "Brake Type",        x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_type, dataKey = "brake_type" }
-fields[16] = { t = "Brake Force %",     x = x + indent, y = incY(lineSpacing), sp = x + sp, data = escParameters.brake_force, dataKey = "brake_force" }
+    local function addSection(section)
+        if not sectionHasFields(section) then return end
+        local gap = section.gap or lineSpacing
+        if section.title then
+            labels[#labels + 1] = { t = section.title, x = x, y = incY(gap) }
+        else
+            y = y + gap - lineSpacing
+        end
+        for i = 1, #section.fields do
+            addField(section.fields[i])
+        end
+    end
+
+    labels[1] = { t = "ESC not ready, waiting...", x = x, y = incY(lineSpacing) }
+    labels[2] = { t = "---", x = x + indent, y = incY(lineSpacing), bold = false }
+    labels[3] = { t = "---", x = x + indent, y = incY(lineSpacing), bold = false }
+
+    for i = 1, #sections do
+        addSection(sections[i])
+    end
+
+    return labels, fields
+end
+
+local labels, fields = buildForm(escParameters)
 
 local function receivedEscParameters(page, data)
+    page.labels, page.fields = buildForm(data)
+
     if data.esc_signature.value ~= 253 then -- Hobbywing Platinum V5 signature
         page.labels[1].t = "Invalid ESC detected"
     else
         page.labels[1].t = data.esc_type.value
         page.labels[2].t = "HW: " .. data.hardware_version.value
         page.labels[3].t = "FW:" .. data.firmware_version.value
-    end
-
-    if data._supported then
-        for i = 1, #page.fields do
-            local field = page.fields[i]
-            field.readOnly = field.dataKey and not data._supported[field.dataKey]
-        end
     end
 
     page.readOnly = false     -- enable 'Save Page'


### PR DESCRIPTION
Ported HW5 model-specific parsing/writing logic to rotorflight-lua-ethos and rotorflight-lua-scripts.
Added HW1121/HW1128/HW1132/OPTO layout handling, including HW1132’s reordered cutoff/BEC fields.
Added HW1132 BEC select mapping for 6.0V, 7.4V, and 8.4V.
Preserve raw untouched HW5 item bytes during writes to avoid clearing model-specific fields.
Fixed select value 0 rendering as ---.
Mark unsupported HW5 fields read-only 